### PR TITLE
BG gradient fix for IE9

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,36 @@
+Provide a general summary of the issue in the Title above
+
+## Expected Behavior
+If you're describing a bug, tell us what should happen
+
+If you're suggesting a change/improvement, tell us how it should work
+
+## Current Behavior
+If describing a bug, tell us what happens instead of the expected behavior
+
+If suggesting a change/improvement, explain the difference from current behavior
+
+## Possible Solution
+Not obligatory, but suggest a fix/reason for the bug,
+or ideas how to implement the addition or change
+
+## Steps to Reproduce (for bugs)
+Provide a link to a live example, or an unambiguous set of steps to
+reproduce this bug. Include code to reproduce, if relevant
+
+- 1.
+- 2.
+- 3.
+- 4.
+
+## Context
+How has this issue affected you? What are you trying to accomplish?
+
+Providing context helps us come up with a solution that is most useful in the real world
+
+## Your Environment
+Include as many relevant details about the environment you experienced the bug in
+
+* Version used:
+* Environment name and version (e.g. Chrome 39, node.js 5.4):
+* Operating System and version (desktop or mobile):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+Provide a general summary of your changes in the Title above
+
+## Description
+Describe your changes in detail
+
+## Related Issue
+Please link to the issue here:
+
+## Motivation and Context
+Why is this change required? What problem does it solve?
+
+## How Has This Been Tested?
+Please describe in detail how you tested your changes.
+
+Include details of your testing environment, and the tests you ran to
+see how your change affects other areas of the code, etc.
+
+## Screenshots (if appropriate):
+
+## Types of changes
+What types of changes does your code introduce? Put an `x` in all the boxes that apply:
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+
+- [ ] New functions and mixins have appropriate tests.
+- [ ] All new and existing tests passed.
+- [ ] Changes have been browser tested (including IE).
+- [ ] I have added instructions on how to test my changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Toolkit Core v0.5.1
+
+## 1. Bug Fixes
+- [page] Solid bg fallback for IE9 to replace broken gradient.
+
+===
+
 # Toolkit Core v0.5.0
 
 ## 1. Enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The core framework of Sky's web toolkit",
   "main": "index.js",
   "scripts": {

--- a/tools/_page.scss
+++ b/tools/_page.scss
@@ -16,8 +16,7 @@
   @include background-gradient("small");
 
   @include mq($from: medium) {
-    background-color: #c9c7d1;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#c9c7d1", endColorstr="#fefefe", GradientType=1);
+    background-color: #fefefe;
     background-image: -webkit-linear-gradient(left, #c9c7d1 0%, #e5e5ea 6%, #fefefe 20%, #fefefe 80%, #e5e5ea 94%, #c9c7d1 100%);
     background-image: -moz-linear-gradient(left, #c9c7d1 0%, #e5e5ea 6%, #fefefe 20%, #fefefe 80%, #e5e5ea 94%, #c9c7d1 100%);
     background-image: -o-linear-gradient(left, #c9c7d1 0%, #e5e5ea 6%, #fefefe 20%, #fefefe 80%, #e5e5ea 94%, #c9c7d1 100%);


### PR DESCRIPTION
## Description
Page background gradients were displaying as 2 point gradients rather than the correct page gradient in IE9:

![screen shot 2016-09-05 at 11 26 40](https://cloud.githubusercontent.com/assets/2472440/18246754/a61719ea-7365-11e6-949e-d24a96a32150.png)

This PR removes the `filter` fallback for IE9 and instead sets a solid colour `#fefefe`:
![screen shot 2016-09-05 at 13 03 01](https://cloud.githubusercontent.com/assets/2472440/18247213/2bb768b8-7369-11e6-9708-efc69c2c8e62.png)


## Related Issue

#131 

## How Has This Been Tested?

Browser tested in:
- IE9
- IE10
- Chrome (mac)

These were tested on local VMs

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.