### PR TITLE
Added function to remove units from a value such as 400px

### DIFF
--- a/test/tools/_functions.scss
+++ b/test/tools/_functions.scss
@@ -113,3 +113,24 @@
     @include assert-equal($actual, $expected);
   }
 }
+
+// $colors map reader
+// ===========================================
+
+@include test-module("@function strip-unit") {
+  @include functions_before();
+
+  @include test("returns a number with no units when a number with units is supplied.") {
+    $actual: strip-unit(20vw);
+    $expected: 20;
+
+    @include assert-equal($actual, $expected);
+  }
+
+  @include test("returns a number with no units when a number with no units is supplied.") {
+    $actual: strip-unit(400);
+    $expected: 400;
+
+    @include assert-equal($actual, $expected);
+  }
+}

--- a/tools/_functions.scss
+++ b/tools/_functions.scss
@@ -55,3 +55,17 @@
   @warn "Unknown `#{$key}` in $gradients.";
   @return null;
 }
+
+// Strip units
+// ===========================================
+
+// Function to remove the unit from a value i.e. strip-unit(20px) would return 20.
+@function strip-unit($num) {
+  @if type_of($num) == number {
+    @return $num / ($num * 0 + 1);
+  }
+
+  @else {
+    @warn "Value must be a number i.e. 12, 24px etc.";
+  }
+}


### PR DESCRIPTION
## Description
Added function to strip units from values such as `20px`, `30em`, `80vh`. This is useful for doing conversions between different types of values and is being used in upcoming toolkit-ui features.

## Related Issue
n/a

## Motivation and Context
Allows us to use functions such as:

```(30px / 1.25rem) * 1em```

using:

```(strip-unit(30px) / strip-unit(1.25rem)) * 1em```

## How Has This Been Tested?
This has been tested locally, to test use the function as described above.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.

