### PR TITLE
Added convert-to-em function and tests

### DIFF
--- a/test/tools/_functions.scss
+++ b/test/tools/_functions.scss
@@ -9,8 +9,6 @@
 // ===========================================
 
 @mixin functions_before() {
-  $global-font-size: 20px;
-
   $text: (
     testKey: (
       small: 18px,

--- a/test/tools/_functions.scss
+++ b/test/tools/_functions.scss
@@ -3,11 +3,14 @@
 // =============================================================================
 
 @import "../../tools/functions";
+@import "../../settings/globals";
 
 // Test configuration
 // ===========================================
 
 @mixin functions_before() {
+  $global-font-size: 20px;
+
   $text: (
     testKey: (
       small: 18px,
@@ -114,7 +117,7 @@
   }
 }
 
-// $colors map reader
+// $strip-unit
 // ===========================================
 
 @include test-module("@function strip-unit") {
@@ -130,6 +133,27 @@
   @include test("returns a number with no units when a number with no units is supplied.") {
     $actual: strip-unit(400);
     $expected: 400;
+
+    @include assert-equal($actual, $expected);
+  }
+}
+
+// $strip-unit
+// ===========================================
+
+@include test-module("@function convert-to-em") {
+  @include functions_before();
+
+  @include test("returns an em value when pixels are supplied.") {
+    $actual: convert-to-em(30px);
+    $expected: 1.5em;
+
+    @include assert-equal($actual, $expected);
+  }
+
+  @include test("returns a number with no units when a number with no units is supplied.") {
+    $actual: convert-to-em(2rem);
+    $expected: 2em;
 
     @include assert-equal($actual, $expected);
   }

--- a/tools/_functions.scss
+++ b/tools/_functions.scss
@@ -77,7 +77,7 @@
 // return 1.5em assuming $global-font-size was 20px.
 @function convert-to-em($value) {
   @if unit($value) == "px" {
-    @return (strip-unit($value) / strip-unit($global-font-size)) * 1em;
+    @return (strip-unit($value / $global-font-size)) * 1em;
   }
 
   @if unit($value) == "rem" {

--- a/tools/_functions.scss
+++ b/tools/_functions.scss
@@ -69,3 +69,23 @@
     @warn "Value must be a number i.e. 12, 24px etc.";
   }
 }
+
+// Convert to em
+// ===========================================
+
+// Function to remove the unit from a value to em i.e. strip-unit(30px) would
+// return 1.5em assuming $global-font-size was 20px.
+@function convert-to-em($value) {
+  @if unit($value) == "px" {
+    @return (strip-unit($value) / strip-unit($global-font-size)) * 1em;
+  }
+
+  @if unit($value) == "rem" {
+    @return strip-unit($value) * 1em;
+  }
+
+  @else {
+    @warn "Value must be em or px";
+  }
+
+}


### PR DESCRIPTION
## Description
This will clean up code following the `strip-unit()`function. It should make the intention of the code a little more readable too.

Before:
$btn-border-width: (strip-unit($global-border-width) / strip-unit($global-font-size)) * 1em !default;

After:
$btn-border-width: convert-to-em($global-border-width) !default;

## Related Issue
n/a

## Motivation and Context
Cleaner and more readable

## How Has This Been Tested?
Added unit tests and checked locally

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
