### PR TITLE
Feature / Full Tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Toolkit Core v0.5.2
+
+## 1. Enhancements
+- [colors] Added `mid` gradient to `gradients` variable map.
+- [functions] Added `convert-to-em` helper to convert em and px values to the equivalent em value ie `convert-to-em(40px) = 2em`.
+- [functions] Added `strip-unit` helper to remove units from a value. ie `strip-unit(400px) = 400`.
+- [gradients] `background-gradient` can now utilise an inverted horizontal direction and percentage overrides.
+
+===
+
 # Toolkit Core v0.5.1
 
 ## 1. Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "The core framework of Sky's web toolkit",
   "main": "index.js",
   "scripts": {

--- a/settings/_colors.scss
+++ b/settings/_colors.scss
@@ -30,6 +30,10 @@ $gradients: (
     start: #cdccd4,
     end: #fff
   ),
+  mid: (
+    start: #e6e6ea,
+    end: #fff
+  ),
   small: (
     start: #f2f2f5,
     end: #fff

--- a/tools/_gradients.scss
+++ b/tools/_gradients.scss
@@ -11,7 +11,7 @@
 // Example usage:
 //
 //   html {
-//     @include background-gradient(sky-sports, horizontal);
+//     @include background-gradient(sky-sports, horizontal-invert, 0% 50%);
 //   }
 //
 // OPTIONS
@@ -21,12 +21,15 @@
 //    - "horizontal" Horizontal 3 point gradient
 //    - "radial" Radial 2 point gradient
 
-@mixin background-gradient($key, $direction:"vertical") {
+@mixin background-gradient($key, $direction:"vertical", $start-stop:0% 100%) {
   @if map-has-key($gradients, $key) {
 
     // Set values from $gradients variable map to local variables
     $startColor: gradient($key, start);
     $endColor: gradient($key, end);
+
+    $startPoint: nth($start-stop, 1);
+    $endPoint: nth($start-stop, 2);
 
     // The direction map stores values for the direction for both prefixed and
     // standard linear-gradient
@@ -35,6 +38,11 @@
       vertical: (
         legacy: "top",
         standard: "to bottom",
+        type: linear
+      ),
+      vertical-invert: (
+        legacy: "bottom",
+        standard: "to top",
         type: linear
       ),
       horizontal: (
@@ -58,12 +66,12 @@
       // Fetch linear or radial
       $type: map-get(map-get($direction-map, $direction), type);
 
-      $gradient-color-points: $startColor 0%, $endColor 100% !default;
+      $gradient-color-points: $startColor $startPoint, $endColor $endPoint !default;
 
       // Force horizontal to conform to brand 3 point gradient and vertical or
       // radial to a 2 point gradient.
       @if ($direction == "radial") {
-        $gradient-color-points: $endColor 0%, $startColor 100%;
+        $gradient-color-points: $endColor $startPoint, $startColor $endPoint;
       }
 
       @else if ($direction == "horizontal") {


### PR DESCRIPTION
Extra features to gradients in toolkit-core for use in Full Tiles

## Description
New "mid" gradient to utilise on hover for full tiles, inverted directions and percentage overrides.

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/128

## Motivation and Context
Provides necessary styles for full tile whilst providing extra functionality to the existing background gradient mixin.

## How Has This Been Tested?
Tests pass on `npm run test`.

## Screenshots (if appropriate):
Achieves the following styles:
<img width="1424" alt="screen shot 2016-09-12 at 11 33 59" src="https://cloud.githubusercontent.com/assets/7349341/18433178/116677f4-78de-11e6-9cef-1fcaf966e0a0.png">

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] ~~Bug fix (non-breaking change which fixes an issue)~~
- [x] New feature (non-breaking change which adds functionality)
- [x] ~~Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
