### PR TITLE
Added updated breakpoint values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [functions] Added `convert-to-em` helper to convert em and px values to the equivalent em value ie `convert-to-em(40px) = 2em`.
 - [functions] Added `strip-unit` helper to remove units from a value. ie `strip-unit(400px) = 400`.
 - [gradients] `background-gradient` can now utilise an inverted horizontal direction and percentage overrides.
+- [settings] Update small breakpoint to 420px.
 
 ===
 

--- a/settings/_breakpoints.scss
+++ b/settings/_breakpoints.scss
@@ -3,7 +3,7 @@
 // =============================================================================
 
 // Define our breakpoints for later use with Sass MQ. The key (e.g. `small`)
-// becomes the alias for a breakpoint; the value (e.g. `320px`) is that point at
+// becomes the alias for a breakpoint; the value (e.g. `420px`) is that point at
 // which that breakpoint kicks in. These pixel values will be conveted into ems
 // by Sass MQ.
 //
@@ -24,14 +24,14 @@
 //     color: red;
 //   }
 //
-//   @media (min-width: 20em) {
+//   @media (min-width: 21em) {
 //     .foo {
 //       color: green;
 //     }
 //   }
 
 $mq-breakpoints: (
-  small:   320px,
+  small:   420px,
   medium:  740px,
   large:   980px,
   x-large: 1300px


### PR DESCRIPTION
## Description
Changes default breakpoint values from:

```
$mq-breakpoints: (
  small:   320px,
  medium:  740px,
  large:   980px,
  x-large: 1300px
) !default;
```

to:

```
$mq-breakpoints: (
  small:   420px,
  medium:  740px,
  large:   980px,
  x-large: 1300px
) !default;
```


## Related Issue
#20 

## Motivation and Context
It was decided that the `small` breakpoint was too small to be particularly useful. The size was increased to a more useable value.

## How Has This Been Tested?
Checked locally, to test include this branch of `toolkit-core`. Any instances where the small breakpoint is used should now take affect at `420px` rather than `320px`. 

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.