### PR TITLE
Optional base font-size for convert-to-em function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1. Enhancements
 - [colors] Added `mid` gradient to `gradients` variable map.
-- [functions] Added `convert-to-em` helper to convert em and px values to the equivalent em value ie `convert-to-em(40px) = 2em`.
+- [functions] Added `convert-to-em` helper to convert em and px values to the equivalent em value ie `convert-to-em(40px) = 2em` with optional base font-size.
 - [functions] Added `strip-unit` helper to remove units from a value. ie `strip-unit(400px) = 400`.
 - [gradients] `background-gradient` can now utilise an inverted horizontal direction and percentage overrides.
 

--- a/test/tools/_functions.scss
+++ b/test/tools/_functions.scss
@@ -155,4 +155,11 @@
 
     @include assert-equal($actual, $expected);
   }
+
+  @include test("returns the correct value when different base font size is set.") {
+    $actual: convert-to-em(20px, 10px);
+    $expected: 2em;
+
+    @include assert-equal($actual, $expected);
+  }
 }

--- a/tools/_functions.scss
+++ b/tools/_functions.scss
@@ -75,9 +75,9 @@
 
 // Function to remove the unit from a value to em i.e. strip-unit(30px) would
 // return 1.5em assuming $global-font-size was 20px.
-@function convert-to-em($value) {
+@function convert-to-em($value, $base-font-size: $global-font-size) {
   @if unit($value) == "px" {
-    @return (strip-unit($value / $global-font-size)) * 1em;
+    @return (strip-unit($value / $base-font-size)) * 1em;
   }
 
   @if unit($value) == "rem" {


### PR DESCRIPTION
## Description
Adds optional base font-size to convert-to-em function allowing it to be used in cases where the elements font-size is not set to $global-font-size such as:

``` scss
.c-tile__title {
  font-size: convert-to-em(text(heading-charlie));
  margin-bottom: convert-to-em($global-spacing-unit-tiny, text(heading-charlie));
}
```

## Related Issue
No issue raised but required by future additions

## Motivation and Context
Makes our convert-to-em more reusable.

## How Has This Been Tested?
Tested locally.

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.