### PR TITLE
Select overflow fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## 2. Enhancements
 - [colors] Added `mid` gradient to `gradients` variable map.
+- [forms] ie9 class to hide gradient text overflow for `c-form-select`.
 - [functions] Added `convert-to-em` helper to convert em and px values to the equivalent em value ie `convert-to-em(40px) = 2em` with optional base font-size.
 - [functions] Added `strip-unit` helper to remove units from a value. ie `strip-unit(400px) = 400`.
 - [gradients] `background-gradient` can now utilise an inverted horizontal direction and percentage overrides.

--- a/utilities/_ie9.scss
+++ b/utilities/_ie9.scss
@@ -18,8 +18,9 @@
   }
 
   /**
-   * Remove custom icon on form select inputs
+   * Remove custom icon and gradient overflow on form select inputs
    */
+  .c-form-select::before,
   .c-form-select::after {
     content: normal;
   }


### PR DESCRIPTION
## Description
ie9 fallback for https://github.com/sky-uk/toolkit-ui/pull/123

## Motivation and Context
As the custom icon isn't visible on ie9, the gradient can be hidden too.

## How Has This Been Tested?
Tested in ie9.

## Screenshots (if appropriate):
![screen shot 2016-09-23 at 11 14 41](https://cloud.githubusercontent.com/assets/7349341/18783255/c5134258-8182-11e6-9389-47e65c2fd14d.png)
![screen shot 2016-09-23 at 11 14 50](https://cloud.githubusercontent.com/assets/7349341/18783257/c6a64886-8182-11e6-9835-49feaede106a.png)


## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] Changes have been browser tested (including IE).
- [x] I have added instructions on how to test my changes.
