### PR TITLE
Refactor / Imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Toolkit Core v1.0.0
 
-## 1. Project Structure
-- devDependecies moved to Dependencies to enable sharing with `toolkit-ui`.
+## 1. Structure
+- [project] devDependecies moved to Dependencies to enable sharing with `toolkit-ui`.
+- [imports] settings and tools now utilise `all` to share imports across `sky-toolkit-core/all` and `sky-toolkit-core/tools`.
 
 ## 2. Features
 - [colors] `ui-` prefixed colors have moved to a `grey-` prefix for greater flexibility.

--- a/_all.scss
+++ b/_all.scss
@@ -6,24 +6,24 @@
  * CONTENTS
  *
  * SETTINGS
- * Config...............Configuration and environment settings.
- * Globals..............Globally available settings for the entire project.
- * Colors...............Brand colours are centrally managed for later use.
- * Typography...........Define our typographical settings in one place.
- * Breakpoints..........Hold sitewide breakpoint values in an array for use with
- *                      Sass MQ.
+ * All..................Because our Settings layer doesn’t actually produce any
+ *                      CSS, we can safely glob all of the files into one import
+ *                      without risk of bloating our compiled stylesheet.
+ *                      This also allows us to easily recycle all of our
+ *                      project-level settings into other Sass file/projects.
+ *                      e.g. `@import "sky-toolkit-core/tools";`
+ *                      Please see `settings/_all.scss` for a full table of
+ *                      contents.
  *
  * TOOLS
- * Sass MQ..............Neat little library for managing and using Media Queries
- *                      throughout the rest of the project.
- * Functions............A collection of custom Sass functions.
- * Mixins...............A collection of custom Sass mixins.
- * Typography...........Mixins specifically for helping with setting type.
- * Gradients............Mixins specifically for helping with creating gradients.
- * Divider..............Mixins specifically for helping with creating styles
- *                      for use in dividers.
- * Page.................Mixin specifically for helping with creating the
- *                      default page background.
+ * All..................Because our Tools layer doesn’t actually produce any
+ *                      CSS, we can safely glob all of the files into one import
+ *                      without risk of bloating our compiled stylesheet.
+ *                      This also allows us to easily recycle all of our
+ *                      project-level settings into other Sass file/projects.
+ *                      e.g. `@import "sky-toolkit-core/tools";`
+ *                      Please see `tools/_all.scss` for a full table of
+ *                      contents.
  *
  * GENERIC
  * Box-sizing...........Better default box-model.
@@ -77,20 +77,10 @@
  */
 
 // Settings
-@import "settings/config";
-@import "settings/globals";
-@import "settings/colors";
-@import "settings/typography";
-@import "settings/breakpoints";
+@import "settings/all";
 
 // Tools
-@import "../sass-mq/mq";
-@import "tools/functions";
-@import "tools/mixins";
-@import "tools/typography";
-@import "tools/gradients";
-@import "tools/divider";
-@import "tools/page";
+@import "tools/all";
 
 // Generic
 @import "generic/box-sizing";

--- a/_tools.scss
+++ b/_tools.scss
@@ -1,5 +1,5 @@
 /* ==========================================================================
-   Tools
+   TOOLS IMPORTS
    ========================================================================== */
 
 /**
@@ -9,17 +9,7 @@
  */
 
 // Settings
-@import "settings/config";
-@import "settings/globals";
-@import "settings/colors";
-@import "settings/typography";
-@import "settings/breakpoints";
+@import "settings/all";
 
 // Tools
-@import "../sass-mq/mq";
-@import "tools/functions";
-@import "tools/mixins";
-@import "tools/typography";
-@import "tools/gradients";
-@import "tools/divider";
-@import "tools/page";
+@import "tools/all";

--- a/settings/_all.scss
+++ b/settings/_all.scss
@@ -1,0 +1,20 @@
+/* ==========================================================================
+   SETTINGS
+   ========================================================================== */
+
+/**
+ * CONTENTS
+ *
+ * Config...............Configuration and environment settings.
+ * Globals..............Globally available settings for the entire project.
+ * Colors...............Brand colours are centrally managed for later use.
+ * Typography...........Define our typographical settings in one place.
+ * Breakpoints..........Hold sitewide breakpoint values in an array for use with
+ *                      Sass MQ.
+ */
+
+@import "config";
+@import "globals";
+@import "colors";
+@import "typography";
+@import "breakpoints";

--- a/tools/_all.scss
+++ b/tools/_all.scss
@@ -1,0 +1,26 @@
+/* ==========================================================================
+   TOOLS
+   ========================================================================== */
+
+/**
+ * CONTENTS
+ *
+ * Sass MQ..............Neat little library for managing and using Media Queries
+ *                      throughout the rest of the project.
+ * Functions............A collection of custom Sass functions.
+ * Mixins...............A collection of custom Sass mixins.
+ * Typography...........Mixins specifically for helping with setting type.
+ * Gradients............Mixins specifically for helping with creating gradients.
+ * Divider..............Mixins specifically for helping with creating styles
+ *                      for use in dividers.
+ * Page.................Mixin specifically for helping with creating the
+ *                      default page background.
+ */
+
+@import "../../sass-mq/mq";
+@import "functions";
+@import "mixins";
+@import "typography";
+@import "gradients";
+@import "divider";
+@import "page";


### PR DESCRIPTION
## Description
Currently we manually import the same imports for `settings/` and `tools/` in both `sky-toolkit-core/all` and `sky-toolkit-core/tools`. To tidy this up, I've used an all in these individual sections (as suggested by @csswizardry)

## Related Issue
https://github.com/sky-uk/toolkit-core/issues/138

## Motivation and Context
Keeps imports DRY when the core inevitable scales and evolves

## How Has This Been Tested?
Tested locally using Toolbelt set-up

## Types of Changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated. (N/A)
- [x] CHANGELOG.md updated.
