### PR TITLE
[Pre-config] Custom font-family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## 4. Bug Fixes
 - [page] Gradient orientation fixed for small devices.
+- [font-face] Prevent Sky Text from outputting if a custom font is defined.
 
 ## 5. Deprecations
 - [legacy-typography] Config switch now fully deprecated.

--- a/generic/_font-face.scss
+++ b/generic/_font-face.scss
@@ -3,22 +3,26 @@
    ========================================================================== */
 
 /**
- * Define our custom `@font-face` rules here in order to use them later on in
+ * Define our custom Sky `@font-face` rules here in order to use them later on in
  * the project.
+ *
+ * We only output this if "Sky Text" is defined in the `$global-font-family`.
  */
-@font-face {
-  font-family: "Sky Text";
-  src: url("//assets.sky.com/fonts/sky_regular.eot");
-  src: url("//assets.sky.com/fonts/sky_regular.woff") format("woff"),
-       url("//assets.sky.com/fonts/sky_regular.ttf") format("truetype"),
-       url("//assets.sky.com/fonts/sky_regular.svg#sky_regular") format("svg");
-}
+@if (str-index(#{$global-font-family}, "Sky Text") != null) {
+  @font-face {
+    font-family: "Sky Text";
+    src: url("//assets.sky.com/fonts/sky_regular.eot");
+    src: url("//assets.sky.com/fonts/sky_regular.woff") format("woff"),
+         url("//assets.sky.com/fonts/sky_regular.ttf") format("truetype"),
+         url("//assets.sky.com/fonts/sky_regular.svg#sky_regular") format("svg");
+  }
 
-@font-face {
-  font-family: "Sky Text";
-  src: url("//assets.sky.com/fonts/sky_medium.eot");
-  src: url("//assets.sky.com/fonts/sky_medium.woff") format("woff"),
-       url("//assets.sky.com/fonts/sky_medium.ttf") format("truetype"),
-       url("//assets.sky.com/fonts/sky_medium.svg#sky_medium") format("svg");
-  font-weight: bold;
+  @font-face {
+    font-family: "Sky Text";
+    src: url("//assets.sky.com/fonts/sky_medium.eot");
+    src: url("//assets.sky.com/fonts/sky_medium.woff") format("woff"),
+         url("//assets.sky.com/fonts/sky_medium.ttf") format("truetype"),
+         url("//assets.sky.com/fonts/sky_medium.svg#sky_medium") format("svg");
+    font-weight: bold;
+  }
 }

--- a/generic/_font-face.scss
+++ b/generic/_font-face.scss
@@ -2,13 +2,13 @@
    GENERIC / FONT-FACE
    ========================================================================== */
 
-/**
- * Define our custom Sky `@font-face` rules here in order to use them later on in
- * the project.
- *
- * We only output this if "Sky Text" is defined in the `$global-font-family`.
- */
 @if (str-index(#{$global-font-family}, "Sky Text") != null) {
+  /**
+   * Define our custom Sky `@font-face` rules here in order to use them later on in
+   * the project.
+   *
+   * We only output this if "Sky Text" is defined in the `$global-font-family`.
+   */
   @font-face {
     font-family: "Sky Text";
     src: url("//assets.sky.com/fonts/sky_regular.eot");


### PR DESCRIPTION
Provide a general summary of your changes in the Title above

## Description
We currently output the Sky Text `@font-face` even if the font-family doesn't contain "Sky Text"

## Related Issue
https://github.com/sky-uk/toolkit-core/issues/143

## Motivation and Context
Extra flexibility and customisation.

## How Has This Been Tested?
Builds and tests pass.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices

## Checklist
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
