### PR TITLE
Reset list styling

### DIFF
--- a/generic/_reset.scss
+++ b/generic/_reset.scss
@@ -29,15 +29,3 @@ li > {
   }
 
 }
-
-/**
- * Set the correct list style for ordered and unordered lists.
- */
-
-ol {
-  list-style-type: decimal;
-}
-
-ul {
-  list-style-type: disc;
-}

--- a/generic/_reset.scss
+++ b/generic/_reset.scss
@@ -29,3 +29,15 @@ li > {
   }
 
 }
+
+/**
+ * Set the correct list style for ordered and unordered lists.
+ */
+
+ol {
+  list-style-type: decimal;
+}
+
+ul {
+  list-style-type: disc;
+}

--- a/utilities/_defence.scss
+++ b/utilities/_defence.scss
@@ -33,10 +33,6 @@
   box-sizing: content-box !important;
   -moz-osx-font-smoothing: initial !important;
   -webkit-font-smoothing: initial !important;
-
-  ul {
-    list-style: none !important;
-  }
 }
 
 .skycom-footer__nav {

--- a/utilities/_defence.scss
+++ b/utilities/_defence.scss
@@ -33,6 +33,10 @@
   box-sizing: content-box !important;
   -moz-osx-font-smoothing: initial !important;
   -webkit-font-smoothing: initial !important;
+
+  ul {
+    list-style: none !important;
+  }
 }
 
 .skycom-footer__nav {

--- a/utilities/_defence.scss
+++ b/utilities/_defence.scss
@@ -66,3 +66,15 @@
     max-width: 1140px !important;
   }
 }
+
+/**
+ * Repair alterations to list style types caused by the masthead.
+ */
+
+ol {
+  list-style-type: decimal;
+}
+
+ul {
+  list-style-type: disc;
+}


### PR DESCRIPTION
## Description

The masthead is currently setting `list-style: none` to all `<ol>` and `<ul>` elements on the page. This will reset the style to its default values.

See https://github.com/sky-uk/masthead/blob/26de12a4fc428cc3314f57cb6f260f3d13712b53/grunt/sass_includes/common/_reset.scss#L7

## Related Issue

n/a

## Motivation and Context

Any lists that are added to a page with the masthead present will not render with the correct styles, and instead will render bare. To fix this, this PR resets the styles to their default values. The masthead and footer are not affected by this change as they have more specific rules applied:
```
.skycom-footer .skycom-footer__nav>ul {
    list-style-type: none;
}
```

## How Has This Been Tested?

Manually tested in Sky Pages (see screenshots below)

## Screenshots (if appropriate)

**Lists with no classes added:**

![screen shot 2016-11-18 at 11 46 51 am](https://cloud.githubusercontent.com/assets/6919706/20429145/c2932dc6-ad84-11e6-8e74-919ea0af2a09.png)

**The footer is unaffected:**

![screen shot 2016-11-18 at 11 46 56 am](https://cloud.githubusercontent.com/assets/6919706/20429146/c454856a-ad84-11e6-8cf6-f297debc6d99.png)


## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
