### PR TITLE
New condition / value to focus style mixin to enable a reduced shadow

### DIFF
--- a/tools/_mixins.scss
+++ b/tools/_mixins.scss
@@ -42,6 +42,10 @@
     box-shadow: 0 1px 3px rgba(color(black), 0.75), 0 1px 15px 3px rgba(color(white), 0.75);
   }
 
+  @elseif ($color == "reduced") {
+    box-shadow: 0 1px 3px rgba(color(black), 0.4), 0 1px 6px 3px rgba(color(highlight), 0.75);
+  }
+
   @else {
     @warn "`#{$color}` is not a valid outline color, it must be `default` or `invert`.";
   }


### PR DESCRIPTION
## Description
There are scenarios where the box-shadow is spread too wide when used on tightly spaced UI elements

## Related Issue
As suggested for calendar component
https://github.com/sky-uk/toolkit-ui/pull/184#pullrequestreview-9889641

## Motivation and Context
Adds more flexibility with the existing mixin

## How Has This Been Tested?
Changed in local prototype. Uses very similar properties to existing so extensive testing it not required. 

## Screenshots (if appropriate)

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x ] Chrome
- [x] Edge
- [x] Firefox
- [x ] IE9
- [x ] IE10
- [x ] IE11
- [x ] Opera
- [x ] Safari
- [x ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [ x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [ x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x ] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.

