### PR TITLE
[Enhancement] z-index map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Toolkit Core v1.3.0
+
+## 1. Features
+- [tools] Added `z-index()` function for more maintainable z-index across the project. Accessed from ⬇
+- [settings] `$z-index` map, containing a range of values for greater consistency.
+
+## 2. Enhancements
+- [template] Further comments on coding-style.
+
+===
+
 # Toolkit Core v1.2.0
 
 ## 1. Dependencies
@@ -66,6 +77,7 @@
 ## 2. Deprecations
 - [legacy-typography] We removed the previous typographic variables in favour of a responsive approach. To deprecate gracefully, a toggle variable has been provided in settings/config. To continue using the previous classes set `$legacy-typography: true;` at the very top of your sass import, before toolkit-core.
 
+===
 
 # Toolkit Core v0.4.0
 
@@ -75,6 +87,7 @@
 ## 2. Deprecations
 - [sass-deprecate] We removed the sass-deprecate library in favour of changelogs and improved release notes
 
+===
 
 # Toolkit Core v0.3.15
 
@@ -83,7 +96,6 @@
 - [utilities] Added `tiny` variation to the spacing utility
 - [tools] Added `radial` to the `background-gradient` mixin
 - [settings] Added `ui-mid` to the `colors` map
-
 
 ## 2. Bug Fixes
 - [layout] Fixed margin left on `o-layout--narrow`

--- a/_template.scss
+++ b/_template.scss
@@ -2,17 +2,25 @@
    LAYER / #FILENAME
    ========================================================================== */
 
+// Filename Settings
+// Common values should be stored in file-specific variables here.
+// 1. Provide line-comments like this.
+$filename-color: #bada55; // 1
+
+/* Sub-heading (e.g. Base, States, Modifiers)
+   =========================================== */
+
 /**
- * Long-form comment.
+ * Class heading
  *
+ * Note: `X` should be replaced with the appropriate layer namespace.
+ *
+ * Long-form comment.
  * This spans multiple lines and is also constrained to no longer than 80
  * characters in width.
  *
  * 1. Provide line-comments like this.
  */
-.X-class {
-  color: red; /* [1] */
+.X-filename {
+  color: $filename-color; /* [1] */
 }
-
-/* Sub-heading
-   =========================================== */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/settings/_all.scss
+++ b/settings/_all.scss
@@ -18,3 +18,4 @@
 @import "colors";
 @import "typography";
 @import "breakpoints";
+@import "z-index";

--- a/settings/_z-index.scss
+++ b/settings/_z-index.scss
@@ -14,12 +14,12 @@
 //   }
 
 $z-index: (
-  under-control:   -200,
-  under-content:   -100,
+  under-control:   -40,
+  under-content:   -20,
   content:         0,
-  over-content:    100,
-  over-control:    200,
-  over-page:       300,
-  over-screen:     400,
-  over-everything: 500,
+  over-content:    20,
+  over-control:    40,
+  over-page:       60,
+  over-screen:     80,
+  over-everything: 100,
 ) !default;

--- a/settings/_z-index.scss
+++ b/settings/_z-index.scss
@@ -1,0 +1,25 @@
+// =============================================================================
+// SETTINGS / Z-INDEX
+// =============================================================================
+
+// Our z-index values are held in maps for ease of use.
+// Access these values using:
+//
+//   z-index($KEY)
+//
+// For example:
+//
+//   .foo {
+//     z-index: z-index(content);
+//   }
+
+$z-index: (
+  under-control:   -200,
+  under-content:   -100,
+  content:         0,
+  over-content:    100,
+  over-control:    200,
+  over-page:       300,
+  over-screen:     400,
+  over-everything: 500,
+) !default;

--- a/test/tools/_functions.scss
+++ b/test/tools/_functions.scss
@@ -26,6 +26,10 @@
   $colors: (
     testColor: #bada55
   ) !global;
+
+  $z-index: (
+    testKey: 100
+  ) !global;
 }
 
 // $text map reader
@@ -110,6 +114,20 @@
   @include test("should return a hex value for given key") {
     $actual: color("testColor");
     $expected: #bada55;
+
+    @include assert-equal($actual, $expected);
+  }
+}
+
+// $z-index map reader
+// ===========================================
+
+@include test-module("@function z-index") {
+  @include functions_before();
+
+  @include test("should return a z-index value for given key") {
+    $actual: z-index("testKey");
+    $expected: 100;
 
     @include assert-equal($actual, $expected);
   }

--- a/tools/_functions.scss
+++ b/tools/_functions.scss
@@ -56,6 +56,26 @@
   @return null;
 }
 
+// $z-index map reader
+// ===========================================
+
+// Function to get z-index values instead of using nested `map-gets`.
+//
+// Usage:
+//
+//   .foo {
+//     z-index: z-index(<key>);
+//   }
+//
+@function z-index($key) {
+  @if map-has-key($z-index, $key) {
+    @return map-get($z-index, $key);
+  }
+
+  @warn "Unknown `#{$key}` in $z-index.";
+  @return null;
+}
+
 // Strip units
 // ===========================================
 

--- a/tools/_mixins-ui.scss
+++ b/tools/_mixins-ui.scss
@@ -40,7 +40,7 @@
 
   margin-bottom: $global-spacing-unit;
   position: relative;
-  z-index: 10;
+  z-index: z-index(over-content);
 
   &::before,
   &::after {


### PR DESCRIPTION
Do we move this to `2.0`?

## Description
- A new `$z-index` map for use across the core, UI and projects that depend on the Toolkit.
- Update `_template.scss`

## Related Issue
https://github.com/sky-uk/toolkit-core/issues/53
https://github.com/sky-uk/toolkit-ui/pull/194

## Motivation and Context
Current z-index situation is messy, difficult to track and difficult to update. A map will help improve consistency and efficiency.

## How Has This Been Tested?
Current tests pass, and a new test have been created to support the new `z-index()` function.

## Screenshots (if appropriate)
N/A

## Types of Changes
- [x] New feature (non-breaking change which adds functionality)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
