### PR TITLE
Move Dev deps to `devDependencies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+# Toolkit Core v1.4.1
+
+## 1. Bug Fixes
+- [package] Moved `mocha` dependency to `devDependencies`
+
+===
+
 # Toolkit Core v1.4.0
 
 ## 1. Dependencies

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit-core#readme",
   "dependencies": {
-    "mocha": "^2.4.5",
     "node-sass": "^3.4.2",
     "pre-commit": "^1.1.2",
     "sass-mq": "^3.2.6",
@@ -32,6 +31,7 @@
     "sky-css-lint": "1.0.0"
   },
   "devDependencies": {
+    "mocha": "^2.4.5",
     "eyeglass": "^1.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {
+    "clean": "rm -rf build",
     "test": "./node_modules/mocha/bin/mocha ./test/sass.js",
     "test-circle": "npm run build && npm run test",
     "lint": "stylelint ./**/*.scss --syntax scss",
-    "build": "mkdir build && cat _all.scss | node-sass --include-path node_modules/ --output-style compressed --precision 9 > build/toolkit-core.css"
+    "build": "npm run clean && mkdir build && cat _all.scss | node-sass --include-path node_modules/ --output-style compressed --precision 9 > build/toolkit-core.css"
   },
   "pre-commit": [
     "lint",
@@ -23,15 +24,13 @@
     "url": "https://github.com/sky-uk/toolkit-core/issues"
   },
   "homepage": "https://github.com/sky-uk/toolkit-core#readme",
-  "dependencies": {
+  "devDependencies": {
+    "eyeglass": "^1.1.2",
+    "mocha": "^2.4.5",
     "node-sass": "^3.4.2",
     "pre-commit": "^1.1.2",
     "sass-mq": "^3.2.6",
     "sass-true": "2.0.3",
     "sky-css-lint": "1.0.0"
-  },
-  "devDependencies": {
-    "mocha": "^2.4.5",
-    "eyeglass": "^1.1.2"
   }
 }


### PR DESCRIPTION
discovered while running validation on the `molecules` package.

Provide a general summary of your changes in the Title above

## Description
Simple move of dev dep in `package.json`

## Related Issue
N/A

## Motivation and Context
Why is this change required?
It's possible that this could cause a failure in `molecules` validation as a side effect.
What problem does it solve?
When we run `npm ll --production` in `molecules` with a react version update, we get:

`npm ERR! missing: mocha@^2.4.5, required by sky-toolkit-core@1.4.0`
What program is it supporting? e.g. Toolkit evolution / Sky Mobile
`molecules`, `toolkit-react`, and all new apps that will be running in `sky-pages-renderer`

## How Has This Been Tested?
Please describe in detail how you tested your changes.
CI

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
CI

## Screenshots (if appropriate)

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
N/A

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- N/A : All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- N/A : New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- N/A : I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
