### PR TITLE
Remove Dropdown icon offset for IE9 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Toolkit Core v1.4.0
+# Toolkit Core v1.5.0
 
 ## 1. Fixes
 - [ie9] Improvements to `c-form-select` functionality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Toolkit Core v1.4.0
 
+## 1. Fixes
+- [ie9] Improvements to `c-form-select` functionality.
+- [[Stylelint]](http://stylelint.io) Fix linting command and amend errors.
+
+===
+
+# Toolkit Core v1.4.0
+
 ## 1. Dependencies
 - [[sky-css-lint]](https://github.com/sky-uk/css) Use sky-css-lint for CSS / Sass linting.
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "sky-toolkit-core",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha ./test/sass.js",
-    "test-circle": "npm run build && npm run test",
-    "lint": "stylelint ./**/*.scss --syntax scss",
-    "build": "mkdir build && cat _all.scss | node-sass --include-path node_modules/ --output-style compressed --precision 9 > build/toolkit-core.css"
+    "test": "node ./node_modules/mocha/bin/mocha ./test/sass.js",
+    "test-circle": "npm run lint && npm run test && npm run build",
+    "lint": "stylelint '**/*.scss' --syntax scss",
+    "build": "mkdir -p ./build && cat _all.scss | node-sass --include-path node_modules/ --output-style compressed > build/toolkit-core.css"
   },
   "pre-commit": [
     "lint",

--- a/test/tools/_divider.scss
+++ b/test/tools/_divider.scss
@@ -26,11 +26,11 @@
 
   @include test("should return a divider gradient for the bottom edge for when no direction is set") {
     @include assert("compiles divider gradient for the bottom edge") {
-      @include input {
+      @include input() {
         @include divider-gradient();
       }
 
-      @include expect {
+      @include expect() {
         background: #c0c0c0;
         background: -webkit-linear-gradient(left, rgba(192, 192, 192, 0), #c0c0c0, rgba(192, 192, 192, 0));
         background: -moz-linear-gradient(left, rgba(192, 192, 192, 0), #c0c0c0, rgba(192, 192, 192, 0));
@@ -43,11 +43,11 @@
 
   @include test("should return a divider gradient for the right edge when a right direction is set") {
     @include assert("compiles divider gradient for the right edge") {
-      @include input {
+      @include input() {
         @include divider-gradient(right);
       }
 
-      @include expect {
+      @include expect() {
         background: #c0c0c0;
         background: -webkit-linear-gradient(top, rgba(192, 192, 192, 0), #c0c0c0, rgba(192, 192, 192, 0));
         background: -moz-linear-gradient(top, rgba(192, 192, 192, 0), #c0c0c0, rgba(192, 192, 192, 0));
@@ -60,11 +60,11 @@
 
   @include test("should return a custom divider gradient for the right edge when a right direction and color is set") {
     @include assert("compiles a custom divider gradient for the right edge") {
-      @include input {
+      @include input() {
         @include divider-gradient(right, $divider-gradient-color);
       }
 
-      @include expect {
+      @include expect() {
         background: #bada55;
         background: -webkit-linear-gradient(top, rgba(186, 218, 85, 0), #bada55, rgba(186, 218, 85, 0));
         background: -moz-linear-gradient(top, rgba(186, 218, 85, 0), #bada55, rgba(186, 218, 85, 0));
@@ -76,17 +76,16 @@
   }
 }
 
-
 @include test-module("@mixin divider-shadow") {
   @include divider_before();
 
   @include test("should return a divider shadow for the bottom edge for when no direction is set") {
     @include assert("compiles divider shadow for the bottom edge") {
-      @include input {
+      @include input() {
         @include divider-shadow();
       }
 
-      @include expect {
+      @include expect() {
         background: -webkit-radial-gradient(50% 0%, rgba(74, 74, 74, 0.15), transparent 40%);
         background: -moz-radial-gradient(50% 0%, rgba(74, 74, 74, 0.15), transparent 40%);
         background: -ms-radial-gradient(50% 0%, rgba(74, 74, 74, 0.15), transparent 40%);
@@ -98,11 +97,11 @@
 
   @include test("should return a divider shadow for the right edge when a right direction is set") {
     @include assert("compiles divider shadow for the right edge") {
-      @include input {
+      @include input() {
         @include divider-shadow(right);
       }
 
-      @include expect {
+      @include expect() {
         background: -webkit-radial-gradient(0 50%, farthest-corner, rgba(74, 74, 74, 0.15), transparent 40%);
         background: -moz-radial-gradient(0 50%, farthest-corner, rgba(74, 74, 74, 0.15), transparent 40%);
         background: -ms-radial-gradient(0 50%, farthest-corner, rgba(74, 74, 74, 0.15), transparent 40%);
@@ -114,11 +113,11 @@
 
   @include test("should return a custom divider shadow for the right edge when a right direction and color is set") {
     @include assert("compiles a custom divider shadow for the right edge") {
-      @include input {
+      @include input() {
         @include divider-shadow(right, $divider-shadow-color);
       }
 
-      @include expect {
+      @include expect() {
         background: -webkit-radial-gradient(0 50%, farthest-corner, #000, transparent 40%);
         background: -moz-radial-gradient(0 50%, farthest-corner, #000, transparent 40%);
         background: -ms-radial-gradient(0 50%, farthest-corner, #000, transparent 40%);

--- a/test/tools/_functions.scss
+++ b/test/tools/_functions.scss
@@ -10,14 +10,14 @@
 
 @mixin functions_before() {
   $text: (
-    testKey: (
+    testkey: (
       small: 18px,
       large: 20px
     )
   ) !global;
 
   $gradients: (
-    testKey: (
+    testkey: (
       end: #000,
       mid: #fff
     )
@@ -52,21 +52,21 @@
   @include functions_before();
 
   @include test("should return a large size value for given key") {
-    $actual: text("testKey", large);
+    $actual: text("testkey", large);
     $expected: 20px;
 
     @include assert-equal($actual, $expected);
   }
 
   @include test("should return a small size value for given key") {
-    $actual: text("testKey", small);
+    $actual: text("testkey", small);
     $expected: 18px;
 
     @include assert-equal($actual, $expected);
   }
 
   @include test("should return a large size value if no variant is provided") {
-    $actual: text("testKey");
+    $actual: text("testkey");
     $expected: 20px;
 
     @include assert-equal($actual, $expected);
@@ -80,21 +80,21 @@
   @include functions_before();
 
   @include test("should return an end hex value for given key") {
-    $actual: gradient("testKey", end);
+    $actual: gradient("testkey", end);
     $expected: #000;
 
     @include assert-equal($actual, $expected);
   }
 
   @include test("should return a mid hex value for given key") {
-    $actual: gradient("testKey", mid);
+    $actual: gradient("testkey", mid);
     $expected: #fff;
 
     @include assert-equal($actual, $expected);
   }
 
   @include test("should return an end hex if no variant is provided") {
-    $actual: gradient("testKey");
+    $actual: gradient("testkey");
     $expected: #000;
 
     @include assert-equal($actual, $expected);

--- a/test/tools/_gradients.scss
+++ b/test/tools/_gradients.scss
@@ -9,7 +9,7 @@
 
 @mixin gradients_before {
   $gradients: (
-    testKey: (
+    testkey: (
       start: #000,
       end: #fff
     )
@@ -24,11 +24,11 @@
 
   @include test("should return a vertical linear gradient for the given key when no direction is set") {
     @include assert("compiles vertical linear gradient") {
-      @include input {
-        @include background-gradient(testKey);
+      @include input() {
+        @include background-gradient(testkey);
       }
 
-      @include expect {
+      @include expect() {
         background-color: #fff;
         background-image: -webkit-linear-gradient(top, #000 0%, #fff 100%);
         background-image: -moz-linear-gradient(top, #000 0%, #fff 100%);
@@ -40,11 +40,11 @@
 
   @include test("should return a vertical linear gradient for the given key when a vertical direction is set") {
     @include assert("compiles vertical linear gradient") {
-      @include input {
-        @include background-gradient(testKey, "vertical");
+      @include input() {
+        @include background-gradient(testkey, "vertical");
       }
 
-      @include expect {
+      @include expect() {
         background-color: #fff;
         background-image: -webkit-linear-gradient(top, #000 0%, #fff 100%);
         background-image: -moz-linear-gradient(top, #000 0%, #fff 100%);
@@ -56,11 +56,11 @@
 
   @include test("should return a horizontal linear gradient for the given key when a horizontal direction is set") {
     @include assert("compiles horizontal linear gradient") {
-      @include input {
-        @include background-gradient(testKey, "horizontal");
+      @include input() {
+        @include background-gradient(testkey, "horizontal");
       }
 
-      @include expect {
+      @include expect() {
         background-color: #fff;
         background-image: -webkit-linear-gradient(left, #000 0%, #fff 50%, #000 100%);
         background-image: -moz-linear-gradient(left, #000 0%, #fff 50%, #000 100%);
@@ -72,11 +72,11 @@
 
   @include test("should return a radial gradient for the given key when a radial direction is set") {
     @include assert("compiles radial linear gradient") {
-      @include input {
-        @include background-gradient(testKey, "radial");
+      @include input() {
+        @include background-gradient(testkey, "radial");
       }
 
-      @include expect {
+      @include expect() {
         background-color: #fff;
         background-image: -webkit-radial-gradient(center, ellipse cover, #fff 0%, #000 100%);
         background-image: -moz-radial-gradient(center, ellipse cover, #fff 0%, #000 100%);

--- a/test/tools/_mixins-ui.scss
+++ b/test/tools/_mixins-ui.scss
@@ -25,22 +25,22 @@
 
   @include test("adds panel indicator") {
     @include assert("sets default theme by default") {
-      @include input {
+      @include input() {
         @include panel-indicator();
       }
 
-      @include expect {
+      @include expect() {
         background-color: #fff;
         box-shadow: inset 11px 11px 11px -11px #9f9f9f;
       }
     }
 
     @include assert("sets dark theme if specified") {
-      @include input {
+      @include input() {
         @include panel-indicator("dark");
       }
 
-      @include expect {
+      @include expect() {
         background-color: #222;
         box-shadow: inset 11px 11px 11px -11px #000;
       }

--- a/test/tools/_mixins.scss
+++ b/test/tools/_mixins.scss
@@ -17,7 +17,6 @@
   ) !global;
 }
 
-
 // Add color to color map (settings/_colors)
 // ===========================================
 
@@ -26,14 +25,14 @@
 
   @include test("should add new key and value to color map") {
     @include assert("merges color map with new values") {
-      @include input {
+      @include input() {
         @include add-color($test-key, $test-value);
         color: map-get($colors, white);
         background: map-get($colors, black);
         border-color: map-get($colors, $test-key);
       }
 
-      @include expect {
+      @include expect() {
         color: #fff;
         background: #000;
         border-color: $test-value;

--- a/test/tools/_typography.scss
+++ b/test/tools/_typography.scss
@@ -26,11 +26,11 @@
 
   @include test("should return font size in pixels and rems") {
     @include assert("pixels and rems should be compiled") {
-      @include input {
+      @include input() {
         @include font-size(test);
       }
 
-      @include expect {
+      @include expect() {
         font-size: 20px;
         font-size: 1rem;
       }
@@ -39,11 +39,11 @@
 
   @include test("should return the provided typography variant") {
     @include assert("small font size should be compiled") {
-      @include input {
+      @include input() {
         @include font-size(test, small);
       }
 
-      @include expect {
+      @include expect() {
         font-size: 18px;
         font-size: 0.9rem;
       }

--- a/utilities/_ie9.scss
+++ b/utilities/_ie9.scss
@@ -18,6 +18,13 @@
   }
 
   /**
+   * Remove custom icon offset.
+   */
+  .c-form-select__dropdown {
+    padding-right: $global-spacing-unit-tiny;
+  }
+
+  /**
    * Remove custom icon and gradient overflow on form select inputs
    */
   .c-form-select::before,


### PR DESCRIPTION
## Description
Compliments https://github.com/sky-uk/toolkit-ui/pull/206

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/205

## Motivation and Context
See https://github.com/sky-uk/toolkit-ui/pull/206

## How Has This Been Tested?
All existing tests pass

## Screenshots (if appropriate)

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
