### PR TITLE
1.6.0

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,1 +1,3 @@
-node_modules/sky-css-lint/.stylelintrc
+{
+  "extends": "stylelint-config-sky-uk"
+}

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "stylelint-config-sky-uk"
+  "extends": "stylelint-config-sky-uk",
+  "rules": {
+    "declaration-no-important": null
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Toolkit Core v1.6.0
+
+## 1. Dependencies
+- [stylelint-config-sky-uk](https://github.com/sky-uk/css) implemented for linting.
+- Dependencies refactored to a flat structure.
+
+## 2. Fixes
+- [Autoprefixer] Utilise `/*! autoprefixer: off */` comments to prevent Autoprefixer rewrites.
+
+===
+
 # Toolkit Core v1.5.0
 
 ## 1. Fixes

--- a/elements/_page.scss
+++ b/elements/_page.scss
@@ -17,6 +17,7 @@
  *    render text using sub-pixel anti-aliasing.
  */
 html {
+  /*! autoprefixer: off */
   @include background-page();
   font-size: ($global-font-size / 16px) * 1em;
   line-height: $global-line-height / $global-font-size;

--- a/elements/_tables.scss
+++ b/elements/_tables.scss
@@ -14,7 +14,6 @@ table {
 
 th,
 td {
-
   &:first-child {
     padding-left: 0; /* [2] */
   }

--- a/generic/_box-sizing.scss
+++ b/generic/_box-sizing.scss
@@ -10,6 +10,7 @@
  */
 
 html {
+  /*! autoprefixer: off */
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -19,6 +20,7 @@ html {
   &,
   &::before,
   &::after {
+    /*! autoprefixer: off */
     -webkit-box-sizing: inherit;
     -moz-box-sizing: inherit;
     box-sizing: inherit;

--- a/generic/_reset.scss
+++ b/generic/_reset.scss
@@ -22,10 +22,8 @@ hr {
  * Remove trailing margins from nested lists.
  */
 li > {
-
   ul,
   ol {
     margin-bottom: 0;
   }
-
 }

--- a/objects/_layout.scss
+++ b/objects/_layout.scss
@@ -72,7 +72,6 @@ $global-spacing-unit: 24px !default;
   @if ($use-markup-fix == false) {
     font-size: 0;
   }
-
 }
 
 .o-layout__item {
@@ -86,7 +85,6 @@ $global-spacing-unit: 24px !default;
     font-size: $global-font-size;
     font-size: ($global-font-size / $global-font-size) * 1rem;
   }
-
 }
 
 /* Gutter size modifiers.
@@ -101,7 +99,6 @@ $global-spacing-unit: 24px !default;
   > .o-layout__item {
     padding-left: $global-spacing-unit-small;
   }
-
 }
 
 /**
@@ -113,7 +110,6 @@ $global-spacing-unit: 24px !default;
   > .o-layout__item {
     padding-left: $global-spacing-unit-large;
   }
-
 }
 
 /**
@@ -125,7 +121,6 @@ $global-spacing-unit: 24px !default;
   > .o-layout__item {
     padding-left: 0;
   }
-
 }
 
 /* Vertical alignment modifiers.
@@ -151,11 +146,9 @@ $global-spacing-unit: 24px !default;
  *   - 2 - - 5
  */
 .o-layout--middle {
-
   > .o-layout__item {
     vertical-align: middle;
   }
-
 }
 
 /**
@@ -178,11 +171,9 @@ $global-spacing-unit: 24px !default;
  *   1 2 3 4 5
  */
 .o-layout--bottom {
-
   > .o-layout__item {
     vertical-align: bottom;
   }
-
 }
 
 /* Fill order modifiers.
@@ -205,7 +196,6 @@ $global-spacing-unit: 24px !default;
   > .o-layout__item {
     text-align: left;
   }
-
 }
 
 /**
@@ -225,7 +215,6 @@ $global-spacing-unit: 24px !default;
   > .o-layout__item {
     text-align: left;
   }
-
 }
 
 /**
@@ -245,7 +234,6 @@ $global-spacing-unit: 24px !default;
   > .o-layout__item {
     direction: ltr;
   }
-
 }
 
 /* Vertical gutter modifiers.
@@ -266,7 +254,6 @@ $global-spacing-unit: 24px !default;
  *   1 2 3 4 5
  */
 .o-layout--spaced {
-
   > .o-layout__item {
     margin-bottom: $global-spacing-unit;
   }
@@ -276,19 +263,15 @@ $global-spacing-unit: 24px !default;
    * the vertical gutters accordingly.
    */
   &.o-layout--narrow {
-
     > .o-layout__item {
       margin-bottom: $global-spacing-unit-small;
     }
-
   }
 
   &.o-layout--wide {
-
     > .o-layout__item {
       margin-bottom: $global-spacing-unit-large;
     }
-
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,14 +24,17 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit-core#readme",
   "dependencies": {
-    "mocha": "^2.4.5",
-    "node-sass": "^3.4.2",
-    "pre-commit": "^1.1.2",
-    "sass-mq": "^3.2.6",
-    "sass-true": "2.0.3",
-    "sky-css-lint": "1.0.0"
+    "sass-mq": "^3.3.2"
   },
   "devDependencies": {
-    "eyeglass": "^1.1.2"
+    "eyeglass": "^1.2.1",
+    "mocha": "^3.2.0",
+    "node-sass": "^4.5.0",
+    "pre-commit": "^1.2.2",
+    "sass-true": "2.0.3",
+    "stylelint": "^7.9.0",
+    "stylelint-config-sky-uk": "3.0.0",
+    "stylelint-scss": "^1.4.3",
+    "stylelint-selector-bem-pattern": "^1.0.0"
   }
 }

--- a/tools/_mixins.scss
+++ b/tools/_mixins.scss
@@ -66,7 +66,6 @@
 // http://snook.ca/archives/html_and_css/hiding-content-for-accessibility
 @mixin hide-visually() {
   /* Hiding elements visually overrides any matching property declarations */
-  /* stylelint-disable declaration-no-important */
   border: 0 !important;
   clip: rect(0 0 0 0) !important;
   height: 1px !important;
@@ -75,26 +74,21 @@
   padding: 0 !important;
   position: absolute !important;
   width: 1px !important;
-  /* stylelint-enable */
 }
 
 // Completely hide content both visually from the screen, and from screenreaders
 // and ATs.
 @mixin hide-completely() {
   /* Hiding elements completely overrides any matching property declarations */
-  /* stylelint-disable declaration-no-important */
   display: none !important;
-  /* stylelint-enable */
 }
 
 // Clearfix mixin for use later in the project
 // ===========================================
 @mixin clearfix() {
-
   &::after {
     content: "";
     display: table;
     clear: both;
   }
-
 }

--- a/utilities/_debug.scss
+++ b/utilities/_debug.scss
@@ -11,12 +11,10 @@
    * already reversed.
    */
   .o-layout--reverse {
-
     > [class*="u-push"],
     > [class*="u-pull"] {
       outline: 10px solid red;
     }
-
   }
 
   /**
@@ -28,7 +26,6 @@
     .o-layout > & {
       outline: none;
     }
-
   }
 
 }

--- a/utilities/_defence.scss
+++ b/utilities/_defence.scss
@@ -10,7 +10,9 @@
 /**
  * Repair alterations to the current masthead caused by the Toolkit.
  */
-#skycom-masthead-wrapper { /* stylelint-disable-line selector-no-id */
+/* stylelint-disable-next-line selector-no-id */
+#skycom-masthead-wrapper {
+  /*! autoprefixer: off */
   background: #fff !important;
   font-size: 16px !important;
   box-sizing: content-box !important;
@@ -29,6 +31,7 @@
  * Repair alterations to the current footer caused by the Toolkit.
  */
 .skycom-footer {
+  /*! autoprefixer: off */
   font-size: 16px !important;
   box-sizing: content-box !important;
   -moz-osx-font-smoothing: initial !important;

--- a/utilities/_defence.scss
+++ b/utilities/_defence.scss
@@ -2,9 +2,6 @@
    UTILITIES / DEFENCE
    ========================================================================== */
 
-/* Defence styles need to fully override existing legacy styles */
-/* stylelint-disable selector-no-id, declaration-no-important  */
-
 /**
  * Sets classic-masthead sass-mq breakpoint.
  */
@@ -13,7 +10,7 @@
 /**
  * Repair alterations to the current masthead caused by the Toolkit.
  */
-#skycom-masthead-wrapper {
+#skycom-masthead-wrapper { /* stylelint-disable-line selector-no-id */
   background: #fff !important;
   font-size: 16px !important;
   box-sizing: content-box !important;
@@ -69,5 +66,3 @@
     max-width: 1140px !important;
   }
 }
-
-/* stylelint-enable */

--- a/utilities/_spacing.scss
+++ b/utilities/_spacing.scss
@@ -13,7 +13,6 @@
  */
 
 /* Spacing utilities will override any matching property declarations */
-/* stylelint-disable declaration-no-important */
 
 $global-spacing-directions: (
   null,
@@ -48,19 +47,14 @@ $global-spacing-sizes: (
     }
 
     @each $size, $value in $global-spacing-sizes {
-
       .u-#{$property}#{$direction}#{$all}#{$size} {
         #{$property}#{$direction}: $value !important;
       }
-
     }
 
     .u-#{$property}#{$direction}#{$all}-none {
       #{$property}#{$direction}: 0 !important;
     }
-
   }
 
 }
-
-/* stylelint-enable */

--- a/utilities/_typography.scss
+++ b/utilities/_typography.scss
@@ -3,7 +3,6 @@
    ========================================================================== */
 
 /* Typography utilities will override any matching property declarations */
-/* stylelint-disable declaration-no-important */
 
 /* Text alignment utilities
    =========================================== */
@@ -46,5 +45,3 @@
 .u-text-constrain {
   max-width: 30em !important;
 }
-
-/* stylelint-enable */

--- a/utilities/_vertical-align.scss
+++ b/utilities/_vertical-align.scss
@@ -8,6 +8,7 @@
  * This class requires a set height on the parent element to function correctly.
  */
 .u-vertical-align-center {
+  /*! autoprefixer: off */
   position: relative;
   top: 50%;
   -webkit-transform: translateY(-50%);
@@ -21,6 +22,7 @@
  * element.
  */
 .u-vertical-align-parent {
+  /*! autoprefixer: off */
   -webkit-transform-style: preserve-3d;
   -moz-transform-style: preserve-3d;
   transform-style: preserve-3d;

--- a/utilities/_widths.scss
+++ b/utilities/_widths.scss
@@ -38,7 +38,6 @@
 // choosing, and with the additional responsive suffix (e.g. `\@large`).
 
 /* Width utilities will override any matching property declarations */
-/* stylelint-disable declaration-no-important */
 
 @mixin widths($widths-columns, $widths-breakpoint: null) {
 
@@ -94,5 +93,3 @@
     @include widths(1 2 3 4 5, \@#{$alias});
   }
 }
-
-/* stylelint-enable declaration-no-important */


### PR DESCRIPTION
## Description
- Tidy up dependencies (by suggestion of @coderas)
- Utilise `stylelint-config-sky-uk`
    - Tidy up project's config and `stylelint-disable` rules
- Autoprefixer protection

## Related Issue
https://github.com/sky-uk/toolkit/issues/174

## Motivation and Context
- Current dependency structure is messy
- Keep up to date with the CSS coding style guide

## How Has This Been Tested?
All tests pass, no visual regressions

Tested in Sky Pages - Autoprefixer no longer overwrites browser prefixes

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
