### PR TITLE
Absolute fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ### Features
 
-* [mixins] edge-positioning mixin to simplify and avoid repeated use of individual edge positioning.
-* [utilities] addition of `u-absolute-fill` to absolutely position an element to fully fill the parent container.
+* [mixins] edge-position mixin to simplify and avoid repeated use of individual edge positioning.
+* [utilities] addition of `u-fill-absolute` to absolutely position an element to fully fill the parent container.
 
 ## 1.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 `sky-toolkit-core` follows [Semantic Versioning](http://semver.org) to help manage the impact of releasing new library versions.
 
 
+## 1.10.0
+
+### Features
+
+* [mixins] edge-positioning mixin to simplify and avoid repeated use of individual edge positioning.
+* [utilities] addition of `u-absolute-fill` to absolutely position an element to fully fill the parent container.
+
 ## 1.9.0
 
 ### Dependencies

--- a/_all.scss
+++ b/_all.scss
@@ -61,6 +61,7 @@
  *
  * UTILITIES
  * Clearfix.............Utility class for applying a clearfix to an element.
+ * Fill.................Utility classes to position an element within its parent.
  * Hide.................Helper classes for hiding content in different ways.
  * Typography...........A suite of helper classes for manipulating typographical
  *                      elements (alignment, size, etc.).
@@ -117,3 +118,4 @@
 @import "utilities/vertical-align";
 @import "utilities/ie9";
 @import "utilities/debug";
+@import "utilities/fill";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/test/tools/_mixins.scss
+++ b/test/tools/_mixins.scss
@@ -153,3 +153,46 @@
     }
   }
 }
+
+// Edge Positioning mixin
+// ===========================================
+
+@include test-module("@mixin edge-positioning") {
+  @include test("when no arguments are given to the edge-positioning mixin") {
+    @include assert("should offest all positions by zero ") {
+      @include input() {
+        .foo {
+          @include edge-positioning()
+        }
+      }
+
+      @include expect() {
+        .foo {
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+        }
+      }
+    }
+  }
+
+  @include test("when an argument is given to the edge-positioning mixin") {
+    @include assert("should offest all positions by the value ") {
+      @include input() {
+        .foo {
+          @include edge-positioning(5px)
+        }
+      }
+
+      @include expect() {
+        .foo {
+          top: 5px;
+          right: 5px;
+          bottom: 5px;
+          left: 5px;
+        }
+      }
+    }
+  }
+}

--- a/test/tools/_mixins.scss
+++ b/test/tools/_mixins.scss
@@ -157,8 +157,8 @@
 // Edge Position mixin
 // ===========================================
 
-@include test-module("@mixin edge-positioning") {
-  @include test("when no arguments are given to the edge-positioning mixin") {
+@include test-module("@mixin edge-position") {
+  @include test("when no arguments are given to the edge-position mixin") {
     @include assert("should offest all positions by zero ") {
       @include input() {
         .foo {
@@ -178,7 +178,7 @@
     }
   }
 
-  @include test("when an argument is given to the edge-positioning mixin") {
+  @include test("when an argument is given to the edge-position mixin") {
     @include assert("should offest all positions by the value ") {
       @include input() {
         .foo {

--- a/test/tools/_mixins.scss
+++ b/test/tools/_mixins.scss
@@ -154,7 +154,7 @@
   }
 }
 
-// Edge Positioning mixin
+// Edge Position mixin
 // ===========================================
 
 @include test-module("@mixin edge-positioning") {
@@ -162,7 +162,7 @@
     @include assert("should offest all positions by zero ") {
       @include input() {
         .foo {
-          @include edge-positioning();
+          @include edge-position();
 
         }
       }
@@ -182,7 +182,7 @@
     @include assert("should offest all positions by the value ") {
       @include input() {
         .foo {
-          @include edge-positioning(5px);
+          @include edge-position(5px);
 
         }
       }

--- a/test/tools/_mixins.scss
+++ b/test/tools/_mixins.scss
@@ -162,7 +162,8 @@
     @include assert("should offest all positions by zero ") {
       @include input() {
         .foo {
-          @include edge-positioning()
+          @include edge-positioning();
+
         }
       }
 
@@ -181,7 +182,8 @@
     @include assert("should offest all positions by the value ") {
       @include input() {
         .foo {
-          @include edge-positioning(5px)
+          @include edge-positioning(5px);
+
         }
       }
 

--- a/tools/_mixins.scss
+++ b/tools/_mixins.scss
@@ -175,3 +175,15 @@
     }
   }
 }
+
+// Edge Positioning Mixin
+// ===========================================
+//
+// Used to simplify and avoid repeated use of individual edge positioning.
+
+@mixin edge-positioning($edge-position-offset: 0) {
+  top: $edge-position-offset;
+  right: $edge-position-offset;
+  bottom: $edge-position-offset;
+  left: $edge-position-offset;
+}

--- a/tools/_mixins.scss
+++ b/tools/_mixins.scss
@@ -176,13 +176,13 @@
   }
 }
 
-// Edge Positioning Mixin
+// Edge Position Mixin
 // ===========================================
 //
 // Used to simplify and avoid repeated use of individual edge positioning.
 // eg. if 5px is passed in as a parameter, all offsets will be set at 5px.
 
-@mixin edge-positioning($edge-position-offset: 0) {
+@mixin edge-position($edge-position-offset: 0) {
   top: $edge-position-offset;
   right: $edge-position-offset;
   bottom: $edge-position-offset;

--- a/tools/_mixins.scss
+++ b/tools/_mixins.scss
@@ -180,6 +180,7 @@
 // ===========================================
 //
 // Used to simplify and avoid repeated use of individual edge positioning.
+// eg. if 5px is passed in as a parameter, all offsets will be set at 5px.
 
 @mixin edge-positioning($edge-position-offset: 0) {
   top: $edge-position-offset;

--- a/utilities/_fill.scss
+++ b/utilities/_fill.scss
@@ -8,8 +8,5 @@
 
 .u-absolute-fill {
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  @include edge-positioning(0);
 }

--- a/utilities/_fill.scss
+++ b/utilities/_fill.scss
@@ -1,0 +1,15 @@
+/* ==========================================================================
+   UTILITIES / FILL
+   ========================================================================== */
+
+/**
+ * Utility classes to position an element within its parent.
+ */
+
+.u-absolute-fill {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}

--- a/utilities/_fill.scss
+++ b/utilities/_fill.scss
@@ -6,8 +6,8 @@
  * Utility classes to position an element within its parent.
  */
 
-.u-absolute-fill {
+.u-fill-absolute {
   position: absolute;
 
-  @include edge-positioning();
+  @include edge-position();
 }

--- a/utilities/_fill.scss
+++ b/utilities/_fill.scss
@@ -8,5 +8,6 @@
 
 .u-absolute-fill {
   position: absolute;
-  @include edge-positioning(0);
+
+  @include edge-positioning();
 }


### PR DESCRIPTION
## Description
Adds the class `.u-absolute-fill`

Also adds the mixin `edge-positioning($edge-position-offset: 0)`

## Related Issue
Fixes https://github.com/sky-uk/sky-pages/issues/3446

## Motivation and Context
Motivated by the fact that we wanted to set the height and background for the responsive-image container for media-tiles before the images have fully loaded. See https://github.com/sky-uk/sky-pages/pull/3815 for more context.

## How Has This Been Tested?
Tests added for the edge-positioning mixin.

This has also been tested manually running the above sky-pages PR locally linked to this PR.

## Screenshots (if appropriate)
The height and background for the wrapper div is set before the image loads.

<img width="1030" alt="responsive_image" src="https://cloud.githubusercontent.com/assets/16287688/24799948/ed25a4c2-1b95-11e7-8135-ee6ae9276046.png">


## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
