### PR TITLE
$global-container-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 `sky-toolkit-core` follows [Semantic Versioning](http://semver.org) to help manage the impact of releasing new library versions.
 
 
+## 1.10.0
+
+### Enhancements
+
+* [globals] Introduction of `$global-container-width` to replace `$container-width` from Layout in 2.0.
+
+
 ## 1.9.0
 
 ### Dependencies

--- a/objects/_container.scss
+++ b/objects/_container.scss
@@ -2,11 +2,12 @@
    OBJECTS / CONTAINER
    ========================================================================== */
 
-// Sets our container max-width to match content allowing for padding.
-$container-width: 1140px + ($global-spacing-unit * 2);
+// The $container-width variable will be removed in Toolkit 2.0.
+// Please use $global-container-width.
+$container-width: $global-container-width;
 
 .o-container {
-  max-width: $container-width;
+  max-width: $global-container-width;
   padding-right: $global-spacing-unit;
   padding-left: $global-spacing-unit;
   margin-right: auto;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/settings/_globals.scss
+++ b/settings/_globals.scss
@@ -9,6 +9,11 @@ $global-font-size: 20px !default;
 $global-line-height: 30px !default;
 $global-font-family: Sky Text, Helvetica, Arial, sans-serif !default;
 
+// Global container settings
+// ==============================================
+
+$global-container-width: 1200px !default;
+
 // Global border settings
 // ==============================================
 


### PR DESCRIPTION
## Description
Add `$container-width` to globals.

## Motivation and Context
Allows us to access variable for use in `sky-toolkit-core/tools`

## Screenshots (if appropriate)
N/A

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
