### PR TITLE
[refs #215] Deprecations for Toolkit 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,27 @@
 `sky-toolkit-core` follows [Semantic Versioning](http://semver.org) to help manage the impact of releasing new library versions.
 
 
+## 1.13.0
+
+### Deprecation Warnings
+
+The following will be removed in Toolkit@2.0.0:
+
+* [tools]
+  * Functions: Removal of `text()`. Use `font-size()` instead.
+  * Mixins: Removal of `@include font-size()`. Use `@include font()` instead.
+* [typography]
+  * Removal of `text-lead-small`. Use `text-body` instead.
+  * Removal of `text-body-small`. Use `text-body` instead.
+* [utilities] Removal of `_defence.scss` due to deprecation of the current masthead.
+
+If you experience any issues with these required changes, please visit https://git.io/v9b7v for next steps.
+
 ## 1.12.0
 
 ### Dependencies
 
-* [[supercell](https://github.com/sky-uk/supercell)] upgrade to utilise `.u-width-auto` classes.
+* [[supercell]](https://github.com/sky-uk/supercell)] upgrade to utilise `.u-width-auto` classes.
 
 
 ## 1.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following will be removed in Toolkit@2.0.0:
 
 If you experience any issues with these required changes, please visit https://git.io/v9b7v for next steps.
 
+
 ## 1.12.0
 
 ### Dependencies

--- a/elements/_typography.scss
+++ b/elements/_typography.scss
@@ -14,7 +14,7 @@
  * http://csswizardry.com/2016/02/managing-typography-on-large-apps/
  */
 h1, h2, h3, h4, h5, h6 {
-  @include font-size(text-body);
+  @include font(text-body);
   font-weight: normal;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/test/tools/_functions.scss
+++ b/test/tools/_functions.scss
@@ -32,7 +32,7 @@
 // ===========================================
 
 // Function to get text instead of using `map-get`.
-@function text($key, $variant:large) {
+@function font-size($key, $variant:large) {
   @if map-has-key($text, $key) {
     @if ($variant != null) {
       @return map-get(map-get($text, $key), $variant);
@@ -48,25 +48,25 @@
 // $text map reader
 // ===========================================
 
-@include test-module("@function text") {
+@include test-module("@function font-size") {
   @include functions_before();
 
   @include test("should return a large size value for given key") {
-    $actual: text("testkey", large);
+    $actual: font-size("testkey", large);
     $expected: 20px;
 
     @include assert-equal($actual, $expected);
   }
 
   @include test("should return a small size value for given key") {
-    $actual: text("testkey", small);
+    $actual: font-size("testkey", small);
     $expected: 18px;
 
     @include assert-equal($actual, $expected);
   }
 
   @include test("should return a large size value if no variant is provided") {
-    $actual: text("testkey");
+    $actual: font-size("testkey");
     $expected: 20px;
 
     @include assert-equal($actual, $expected);

--- a/test/tools/_typography.scss
+++ b/test/tools/_typography.scss
@@ -21,13 +21,13 @@
 // Font size mixin
 // ===========================================
 
-@include test-module("@mixin font-size") {
+@include test-module("@mixin font") {
   @include typography_before();
 
   @include test("should return font size in pixels and rems") {
     @include assert("pixels and rems should be compiled") {
       @include input() {
-        @include font-size(test);
+        @include font(test);
       }
 
       @include expect() {
@@ -40,7 +40,7 @@
   @include test("should return the provided typography variant") {
     @include assert("small font size should be compiled") {
       @include input() {
-        @include font-size(test, small);
+        @include font(test, small);
       }
 
       @include expect() {

--- a/tools/_all.scss
+++ b/tools/_all.scss
@@ -17,6 +17,7 @@
  *                      for use in dividers.
  * Page.................Mixin specifically for helping with creating the
  *                      default page background.
+ * Legacy...............Temporary wrappers for tools to be deprecated.
  */
 
 @import "sass-mq/mq";
@@ -28,3 +29,4 @@
 @import "gradients";
 @import "divider";
 @import "page";
+@import "legacy";

--- a/tools/_functions.scss
+++ b/tools/_functions.scss
@@ -5,9 +5,20 @@
 // $text map reader
 // ===========================================
 
-// Function to get text instead of using `map-get`.
-@function text($key, $variant:large) {
+// Function to get font-size instead of using `map-get`.
+@function font-size($key, $variant:large) {
   @if map-has-key($text, $key) {
+
+    // Warning to be removed Toolkit@2.0.0
+    /* stylelint-disable string-no-newline */
+    @if $key == "text-lead-small" or $key == "text-body-small" {
+      @warn "Deprecation [typography]: `#{$key}`
+      Support for `#{$key}` (and `.c-#{$key}`) will be removed in Toolkit@2.0.0.
+      Use `text-body` (or `.c-text-body`) instead.
+      If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
+    }
+    /* stylelint-enable */
+
     @if ($variant != null) {
       @return map-get(map-get($text, $key), $variant);
     }
@@ -87,5 +98,4 @@
   @else {
     @warn "Value must be em or px";
   }
-
 }

--- a/tools/_functions.scss
+++ b/tools/_functions.scss
@@ -6,16 +6,18 @@
 // ===========================================
 
 // Function to get font-size instead of using `map-get`.
-@function font-size($key, $variant:large) {
+@function font-size($key, $variant:large, $legacy-warning:null) {
   @if map-has-key($text, $key) {
 
     // Warning to be removed Toolkit@2.0.0
     /* stylelint-disable string-no-newline */
-    @if $key == "text-lead-small" or $key == "text-body-small" {
-      @warn "Deprecation [typography]: `#{$key}`
-      Support for `#{$key}` (and `.c-#{$key}`) will be removed in Toolkit@2.0.0.
-      Use `text-body` (or `.c-text-body`) instead.
-      If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
+    @if $legacy-warning != "disable-warning" {
+      @if $key == "text-lead-small" or $key == "text-body-small" {
+        @warn "Deprecation [typography]: `#{$key}`
+        Support for `#{$key}` (and `.c-#{$key}`) will be removed in Toolkit@2.0.0.
+        Use `text-body` (or `.c-text-body`) instead.
+        If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
+      }
     }
     /* stylelint-enable */
 

--- a/tools/_legacy.scss
+++ b/tools/_legacy.scss
@@ -1,0 +1,41 @@
+// =============================================================================
+// TOOLS / LEGACY
+// =============================================================================
+
+/* stylelint-disable string-no-newline */
+
+// In order to support our legacy tooling, wrappers are provided for modified
+// mixins and functions.
+// This allows developers to use the older Toolkit API before removal.
+
+// All the following will be removed Toolkit@2.0.0.
+
+// Functions
+// =============================================================================
+
+// $text map reader
+// ===========================================
+
+// Please see tools/functions for `font-size()` replacement.
+@function text($args...) {
+  @warn "Deprecation [function]: `text()`
+  Support for `text()` will be removed in Toolkit@2.0.0. Use `font-size()` instead.
+  If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
+  @return font-size($args...);
+}
+
+// Mixins
+// =============================================================================
+
+// Font-sizing and vertical rhythm mixin
+// ===========================================
+
+// Please see tools/typography for `text()` replacement.
+@mixin font-size($args...) {
+  @include font($args...);
+  @warn "Deprecation [mixin]: `font-size()`
+  Support for `font-size()` will be removed in Toolkit@2.0.0. Use `font()` instead.
+  If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
+}
+
+/* stylelint-enable */

--- a/tools/_legacy.scss
+++ b/tools/_legacy.scss
@@ -33,8 +33,8 @@
 // Please see tools/typography for `text()` replacement.
 @mixin font-size($args...) {
   @include font($args...);
-  @warn "Deprecation [mixin]: `font-size()`
-  Support for `font-size()` will be removed in Toolkit@2.0.0. Use `font()` instead.
+  @warn "Deprecation [mixin]: `@include font-size()`
+  Support for `@include font-size()` will be removed in Toolkit@2.0.0. Use `@include font()` instead.
   If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
 }
 

--- a/tools/_typography.scss
+++ b/tools/_typography.scss
@@ -19,9 +19,10 @@
 //     font-size: 1rem;
 // }
 //
+// legacy-warning to be removed in Toolkit@2.0.0
 
-@mixin font($key, $variant:large) {
-  $font-size: font-size($key, $variant);
+@mixin font($key, $variant:large, $legacy-warning:null) {
+  $font-size: font-size($key, $variant, $legacy-warning);
   font-size: $font-size;
   font-size: ($font-size / $global-font-size) * 1rem;
 }

--- a/tools/_typography.scss
+++ b/tools/_typography.scss
@@ -20,8 +20,8 @@
 // }
 //
 
-@mixin font-size($key, $variant:large) {
-  $font-size: text($key, $variant);
+@mixin font($key, $variant:large) {
+  $font-size: font-size($key, $variant);
   font-size: $font-size;
   font-size: ($font-size / $global-font-size) * 1rem;
 }

--- a/utilities/_defence.scss
+++ b/utilities/_defence.scss
@@ -2,6 +2,12 @@
    UTILITIES / #DEFENCE
    ========================================================================== */
 
+/* stylelint-disable string-no-newline */
+@warn "Deprecation [utility]: Defence
+Support for `_defence.scss` will be removed in Toolkit@2.0.0 due to deprecation of the existing Masthead.
+If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
+/* stylelint-enable */
+
 // Defence Settings
 // 1. Sets classic-masthead sass-mq breakpoint.
 // 2. Sets default Tile themes to defend.


### PR DESCRIPTION
## Description
- [x] Rename `font-size()` mixin to `font()`
- [x] Add parameter to disable warnings for deprecated font-sizes.
- [x] Rename `text()` function to `font-size()`
- [x] Remove `text-lead-small` and `text-body-small`
- [x] Remove Defence

## Related Issue
https://github.com/sky-uk/toolkit/issues/215

## Motivation and Context
Toolkit 2.0 preparation

## How Has This Been Tested?
All test pass, no change in outputted markup

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
