### PR TITLE
Add orange colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 `sky-toolkit-core` follows [Semantic Versioning](http://semver.org) to help manage the impact of releasing new library versions.
 
 
+## 1.14.0
+
+### Features
+
+* [colors] Add `color(offer)`.
+
+
 ## 1.13.0
 
 ### Deprecation Warnings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/settings/_colors.scss
+++ b/settings/_colors.scss
@@ -24,7 +24,7 @@ $colors: (
   text:      #4a4a4a,
   black:     #000,
   white:     #fff,
-  offer:     #F15A22
+  offer:     #f15a22
 ) !default;
 
 $gradients: (

--- a/settings/_colors.scss
+++ b/settings/_colors.scss
@@ -23,7 +23,8 @@ $colors: (
   grey-50:   #222,
   text:      #4a4a4a,
   black:     #000,
-  white:     #fff
+  white:     #fff,
+  offer:     #F15A22
 ) !default;
 
 $gradients: (


### PR DESCRIPTION
## Description
Add orange colour.

## Motivation and Context
To allow consistency with orange font styling across Sky.
Lack of defined orange colour.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
N/A

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
