### PR TITLE
[refs #00207] Move font-face to top of CSS

### DIFF
--- a/_all.scss
+++ b/_all.scss
@@ -26,13 +26,13 @@
  *                      contents.
  *
  * GENERIC
+ * Font-face............Our @font-face definitions for custom fonts.
  * Box-sizing...........Better default box-model.
  * Normalize.css........Normalise differences across different browsers.
  * Reset................Simple reset to complement Normalize.css: set everything
  *                      to zero.
  * Vertical Rhythm......Define common vertical spacing across all block-level
  *                      elements in one go.
- * Font-face............Our @font-face definitions for custom fonts.
  * Generic..............Our @keyframe definitions for animations.
  *
  * ELEMENTS
@@ -87,11 +87,11 @@
 @import "tools/all";
 
 // Generic
+@import "generic/font-face";
 @import "generic/box-sizing";
 @import "normalize.css/normalize";
 @import "generic/reset";
 @import "generic/vertical-rhythm";
-@import "generic/font-face";
 @import "generic/keyframes";
 
 // Elements


### PR DESCRIPTION
Given that `@font-face` declarations are inert, they can be placed
wherever we like in the CSS with no impact on rendering/styling. To
encourage the browser to find them sooner, let’s move them further up
the CSS file.