### PR TITLE
Add new rem() mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Features
 
-* [tools] Add `rem() mixin`.
+* [tools] Add `rem()` mixin.
 
 ## 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 `sky-toolkit-core` follows [Semantic Versioning](http://semver.org) to help manage the impact of releasing new library versions.
 
 
+## 1.15.0
+
+### Features
+
+* [tools] Add `rem() mixin`.
+
 ## 1.14.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/test/tools/_typography.scss
+++ b/test/tools/_typography.scss
@@ -50,3 +50,21 @@
     }
   }
 }
+
+// Rem generator mixin
+// ===========================================
+
+@include test-module("@mixin rem") {
+  @include test("should return font size in pixels and rems") {
+    @include assert("pixels and rems should be compiled") {
+      @include input() {
+        @include rem(20px);
+      }
+
+      @include expect() {
+        font-size: 20px;
+        font-size: 1rem;
+      }
+    }
+  }
+}

--- a/tools/_typography.scss
+++ b/tools/_typography.scss
@@ -12,17 +12,25 @@
 //     @include font-size(text-body);
 // }
 //
+// legacy-warning to be removed in Toolkit@2.0.0
+
+@mixin font($key, $variant:large, $legacy-warning:null) {
+  $font-size: font-size($key, $variant, $legacy-warning);
+
+  @include rem($font-size);
+}
+
+// px to rem generator
+// ===========================================
+
 // This will generate a rem-based font-size with its pixel fallback e.g:
 //
 // .foo {
 //     font-size: 20px;
 //     font-size: 1rem;
 // }
-//
-// legacy-warning to be removed in Toolkit@2.0.0
 
-@mixin font($key, $variant:large, $legacy-warning:null) {
-  $font-size: font-size($key, $variant, $legacy-warning);
-  font-size: $font-size;
-  font-size: ($font-size / $global-font-size) * 1rem;
+@mixin rem($value) {
+  font-size: $value;
+  font-size: ($value / $global-font-size) * 1rem;
 }

--- a/tools/_typography.scss
+++ b/tools/_typography.scss
@@ -37,6 +37,9 @@
 // }
 
 @mixin rem($value) {
+  @if unit($value) != "px" {
+    @warn "Value must by a px unit";
+  }
   font-size: $value;
   font-size: ($value / $global-font-size) * 1rem;
 }

--- a/tools/_typography.scss
+++ b/tools/_typography.scss
@@ -23,7 +23,13 @@
 // px to rem generator
 // ===========================================
 
-// This will generate a rem-based font-size with its pixel fallback e.g:
+// Generates a rem-based font-size with its pixel fallback e.g:
+//
+// .foo {
+//     @include rem(20px);
+// }
+//
+// Will output:
 //
 // .foo {
 //     font-size: 20px;


### PR DESCRIPTION
## Description

Abstract out the `rem` unit generation from the `font()` mixin so that it can be used independently.

## Motivation and Context

When we need to use hard-coded font-size values (when it doesn't make sense to use the `font()` mixin) we currently need to hardcode two separate px and rem units. This mixin means you only need to write `@include rem(16px)` to generate both values.

## How Has This Been Tested?

Checked in Sassmeister to ensure mixin generated expected output, checked existing tests pass, and wrote new test for `rem()` mixin.

Also checked that the generated build remains unchanged. 

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
