### PR TITLE
z-index

### DIFF
--- a/settings/_all.scss
+++ b/settings/_all.scss
@@ -11,6 +11,7 @@
  * Typography...........Define our typographical settings in one place.
  * Breakpoints..........Hold sitewide breakpoint values in an array for use with
  *                      Sass MQ.
+ * z-index..............Centrally managed z-index settings.
  */
 
 @import "config";
@@ -18,3 +19,4 @@
 @import "colors";
 @import "typography";
 @import "breakpoints";
+@import "z-index";

--- a/settings/_z-index.scss
+++ b/settings/_z-index.scss
@@ -1,0 +1,28 @@
+// =============================================================================
+// SETTINGS / #Z-INDEX
+// =============================================================================
+
+// Our framework (and recommended consumer) z-index values are held in a map.
+// Access these values using:
+//
+//   z-index($KEY)
+//
+// For example:
+//
+//   .foo {
+//     color: z-index(5);
+//   }
+
+$z-index: (
+  0: 0,
+  1: 10,
+  2: 20,
+  3: 30,
+  4: 40,
+  5: 50,
+  6: 60,
+  7: 70,
+  8: 80,
+  9: 90,
+  10: 100,
+) !default;

--- a/test/functional/_all.scss
+++ b/test/functional/_all.scss
@@ -1,6 +1,10 @@
+// Import Sass-True
 @import "true";
 
-// Import Test files
+// Import Settings for Access During Tests
+@import "../../settings/all";
+
+// Import Tests
 @import "tools/functions";
 @import "tools/gradients";
 @import "tools/divider";
@@ -8,5 +12,5 @@
 @import "tools/mixins-ui";
 @import "tools/typography";
 
-// Run the tests
+// Run Tests
 @include report();

--- a/test/functional/tools/_functions.scss
+++ b/test/functional/tools/_functions.scss
@@ -32,6 +32,10 @@
   $colors: (
     test: #bada55
   ) !global;
+
+  $z-index: (
+    test: 100
+  ) !global;
 }
 
 // color()
@@ -176,6 +180,20 @@
   @include test("returns a number with no units when a number with no units is supplied.") {
     $actual: strip-unit(400);
     $expected: 400;
+
+    @include assert-equal($actual, $expected);
+  }
+}
+
+// z-index()
+// ===========================================
+
+@include test-module("@function z-index") {
+  @include functions_before();
+
+  @include test("should return a value for given key.") {
+    $actual: z-index("test");
+    $expected: 100;
 
     @include assert-equal($actual, $expected);
   }

--- a/test/functional/tools/_functions.scss
+++ b/test/functional/tools/_functions.scss
@@ -2,11 +2,9 @@
 // TEST / TOOLS / FUNCTIONS
 // =============================================================================
 
-@import "../../../tools/functions";
-@import "../../../settings/all";
-
-// Test Configuration
+// Import File to Test
 // ===========================================
+@import "../../../tools/functions";
 
 // color()
 // ===========================================

--- a/test/functional/tools/_functions.scss
+++ b/test/functional/tools/_functions.scss
@@ -3,50 +3,18 @@
 // =============================================================================
 
 @import "../../../tools/functions";
-@import "../../../settings/globals";
+@import "../../../settings/all";
 
 // Test Configuration
 // ===========================================
-
-@mixin functions_before() {
-  $text: (
-    test: (
-      small: (
-        font-size: 18px,
-        line-height: 1.5
-      ),
-      large: (
-        font-size: 20px,
-        line-height: 1.4
-      )
-    )
-  ) !global;
-
-  $gradients: (
-    test: (
-      end: #000,
-      mid: #fff
-    )
-  ) !global;
-
-  $colors: (
-    test: #bada55
-  ) !global;
-
-  $z-index: (
-    test: 100
-  ) !global;
-}
 
 // color()
 // ===========================================
 
 @include test-module("@function color") {
-  @include functions_before();
-
   @include test("should return a hex value for given key.") {
-    $actual: color("test");
-    $expected: #bada55;
+    $actual: color(white);
+    $expected: #fff;
 
     @include assert-equal($actual, $expected);
   }
@@ -56,8 +24,6 @@
 // ===========================================
 
 @include test-module("@function convert-to-em") {
-  @include functions_before();
-
   @include test("returns an em value when pixels are supplied.") {
     $actual: convert-to-em(27px);
     $expected: 1.5em;
@@ -84,25 +50,23 @@
 // ===========================================
 
 @include test-module("@function font-size") {
-  @include functions_before();
-
   @include test("should return a large font-size value for given key.") {
-    $actual: font-size(test, large);
-    $expected: 20px;
-
-    @include assert-equal($actual, $expected);
-  }
-
-  @include test("should return a small font-size value for given key.") {
-    $actual: font-size(test, small);
+    $actual: font-size(text-body, large);
     $expected: 18px;
 
     @include assert-equal($actual, $expected);
   }
 
+  @include test("should return a small font-size value for given key.") {
+    $actual: font-size(text-body, small);
+    $expected: 16px;
+
+    @include assert-equal($actual, $expected);
+  }
+
   @include test("should return a large font-size value if no variant is provided.") {
-    $actual: font-size(test);
-    $expected: 20px;
+    $actual: font-size(text-body);
+    $expected: 18px;
 
     @include assert-equal($actual, $expected);
   }
@@ -112,25 +76,23 @@
 // ===========================================
 
 @include test-module("@function gradient") {
-  @include functions_before();
-
-  @include test("should return an end hex value for given key.") {
-    $actual: gradient("test", end);
-    $expected: #000;
+  @include test("should return a start hex value for given key.") {
+    $actual: gradient("sky-1", start);
+    $expected: #0082dc;
 
     @include assert-equal($actual, $expected);
   }
 
-  @include test("should return a mid hex value for given key.") {
-    $actual: gradient("test", mid);
-    $expected: #fff;
+  @include test("should return an end hex value for given key.") {
+    $actual: gradient("sky-1", end);
+    $expected: #1ea0f5;
 
     @include assert-equal($actual, $expected);
   }
 
   @include test("should return an end hex if no variant is provided.") {
-    $actual: gradient("test");
-    $expected: #000;
+    $actual: gradient("sky-1");
+    $expected: #1ea0f5;
 
     @include assert-equal($actual, $expected);
   }
@@ -140,25 +102,23 @@
 // ===========================================
 
 @include test-module("@function line-height") {
-  @include functions_before();
-
   @include test("should return a large line-height value for given key.") {
-    $actual: line-height(test, large);
-    $expected: 1.4;
+    $actual: line-height(text-body, large);
+    $expected: 1.44;
 
     @include assert-equal($actual, $expected);
   }
 
   @include test("should return a small line-height value for given key.") {
-    $actual: line-height(test, small);
+    $actual: line-height(text-body, small);
     $expected: 1.5;
 
     @include assert-equal($actual, $expected);
   }
 
   @include test("should return a large line-height value if no variant is provided.") {
-    $actual: line-height(test);
-    $expected: 1.4;
+    $actual: line-height(text-body);
+    $expected: 1.44;
 
     @include assert-equal($actual, $expected);
   }
@@ -168,8 +128,6 @@
 // ===========================================
 
 @include test-module("@function strip-unit") {
-  @include functions_before();
-
   @include test("returns a number with no units when a number with units is supplied.") {
     $actual: strip-unit(20vw);
     $expected: 20;
@@ -189,11 +147,9 @@
 // ===========================================
 
 @include test-module("@function z-index") {
-  @include functions_before();
-
   @include test("should return a value for given key.") {
-    $actual: z-index("test");
-    $expected: 100;
+    $actual: z-index(1);
+    $expected: 10;
 
     @include assert-equal($actual, $expected);
   }

--- a/tools/_functions.scss
+++ b/tools/_functions.scss
@@ -114,3 +114,23 @@
     @warn "Value must be em or px.";
   }
 }
+
+// z-index()
+// ===========================================
+
+// Function to get value from `$z-index` instead of using `map-get`.
+//
+// Usage:
+//
+//   .foo {
+//     z-index: z-index(<key>);
+//   }
+//
+@function z-index($key) {
+  @if map-has-key($z-index, $key) {
+    @return map-get($z-index, $key);
+  }
+
+  @warn "Unknown `#{$key}` in $z-index.";
+  @return null;
+}

--- a/tools/_mixins-ui.scss
+++ b/tools/_mixins-ui.scss
@@ -40,7 +40,7 @@
 
   margin-bottom: $global-spacing-unit;
   position: relative;
-  z-index: 10;
+  z-index: z-index(1);
 
   &::before,
   &::after {

--- a/utilities/_defence.scss
+++ b/utilities/_defence.scss
@@ -4,7 +4,7 @@
 
 /* stylelint-disable string-no-newline */
 @warn "Deprecation [utility]: Defence
-Support for `_defence.scss` will be removed in Toolkit@2.0.0 due to deprecation of the existing Masthead.
+Support for `_defence.scss` will be removed in Toolkit@3.0.0 due to deprecation of the existing Masthead.
 If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
 /* stylelint-enable */
 


### PR DESCRIPTION
## Description
Implementation of `z-index` strategy proposed by @csswizardry:
- `$z-index` sass map
- Function (and text) to access the map

At first, I was concerned that these keys would be more flexible in tens (like our grey palette) but I think 10 layers is more than enough for use within our framework.

## Related Issue
https://github.com/sky-uk/toolkit/issues/176

## Motivation and Context
Toolkit 2.0 Progression

## How Has This Been Tested?
All existing tests pass, new test added.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
