### PR TITLE
Deprecate Gradient Mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 `sky-toolkit-core` follows [Semantic Versioning](http://semver.org) to help manage the impact of releasing new library versions.
 
 
+## 1.16.0
+
+### Deprecation Warnings
+
+The following will be removed in Toolkit@2.0.0:
+
+* [tools]
+  * Gradients: Removal of `@include background-gradient()`. Use `@include gradient-background()` instead.
+  * Page: Removal of `@include background-page()`. Use `@include page-background()` instead.
+
+If you experience any issues with these required changes, please visit https://git.io/v9b7v for next steps.
+
+
 ## 1.15.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ If you experience any issues with these required changes, please visit https://g
 
 * [tools] Add `rem()` mixin.
 
+
 ## 1.14.0
 
 ### Features

--- a/elements/_page.scss
+++ b/elements/_page.scss
@@ -18,7 +18,7 @@
  */
 html {
   /*! autoprefixer: off */
-  @include background-page();
+  @include page-background();
   font-size: ($global-font-size / 16px) * 1em;
   line-height: $global-line-height / $global-font-size;
   font-family: $global-font-family;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit-core",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "The core of Sky's CSS Toolkit",
   "main": "index.js",
   "scripts": {

--- a/test/tools/_gradients.scss
+++ b/test/tools/_gradients.scss
@@ -19,13 +19,13 @@
 // Background gradient mixin
 // ===========================================
 
-@include test-module("@mixin background-gradient") {
+@include test-module("@mixin gradient-background") {
   @include gradients_before();
 
   @include test("should return a vertical linear gradient for the given key when no direction is set") {
     @include assert("compiles vertical linear gradient") {
       @include input() {
-        @include background-gradient(testkey);
+        @include gradient-background(testkey);
       }
 
       @include expect() {
@@ -41,7 +41,7 @@
   @include test("should return a vertical linear gradient for the given key when a vertical direction is set") {
     @include assert("compiles vertical linear gradient") {
       @include input() {
-        @include background-gradient(testkey, "vertical");
+        @include gradient-background(testkey, "vertical");
       }
 
       @include expect() {
@@ -57,7 +57,7 @@
   @include test("should return a horizontal linear gradient for the given key when a horizontal direction is set") {
     @include assert("compiles horizontal linear gradient") {
       @include input() {
-        @include background-gradient(testkey, "horizontal");
+        @include gradient-background(testkey, "horizontal");
       }
 
       @include expect() {
@@ -73,7 +73,7 @@
   @include test("should return a radial gradient for the given key when a radial direction is set") {
     @include assert("compiles radial linear gradient") {
       @include input() {
-        @include background-gradient(testkey, "radial");
+        @include gradient-background(testkey, "radial");
       }
 
       @include expect() {

--- a/tools/_gradients.scss
+++ b/tools/_gradients.scss
@@ -2,7 +2,7 @@
 // TOOLS / GRADIENTS
 // =============================================================================
 
-// Background Gradient generator
+// @mixin gradient-background()
 // ===========================================
 
 // Mixin to generate complete background gradients. Uses values from our map in
@@ -11,7 +11,7 @@
 // Example usage:
 //
 //   html {
-//     @include background-gradient(sky-sports, horizontal-invert, 0% 50%);
+//     @include gradient-background(sky-sports, horizontal-invert, 0% 50%);
 //   }
 //
 // OPTIONS
@@ -21,7 +21,7 @@
 //    - "horizontal" Horizontal 3 point gradient
 //    - "radial" Radial 2 point gradient
 
-@mixin background-gradient($key, $direction:"vertical", $start-stop:0% 100%) {
+@mixin gradient-background($key, $direction:"vertical", $start-stop:0% 100%) {
   @if map-has-key($gradients, $key) {
 
     // Set values from $gradients variable map to local variables

--- a/tools/_legacy.scss
+++ b/tools/_legacy.scss
@@ -30,7 +30,7 @@
 // Background gradient generator mixin
 // ===========================================
 
-// Please see tools/gradients for `@include gradient-background()` replacement.
+// Please see tools/gradients for `@include background-gradient()` replacement.
 @mixin background-gradient($args...) {
   @include gradient-background($args...);
   @warn "Deprecation [mixin]: `@include background-gradient()`
@@ -52,7 +52,7 @@
 // Background gradient page mixin
 // ===========================================
 
-// Please see tools/page for `@include page-background()` replacement.
+// Please see tools/page for `@include background-page()` replacement.
 @mixin background-page($args...) {
   @include page-background($args...);
   @warn "Deprecation [mixin]: `@include background-page()`

--- a/tools/_legacy.scss
+++ b/tools/_legacy.scss
@@ -27,14 +27,36 @@
 // Mixins
 // =============================================================================
 
+// Background gradient generator mixin
+// ===========================================
+
+// Please see tools/gradients for `@include gradient-background()` replacement.
+@mixin background-gradient($args...) {
+  @include gradient-background($args...);
+  @warn "Deprecation [mixin]: `@include background-gradient()`
+  Support for `@include background-gradient()` will be removed in Toolkit@2.0.0. Use `@include gradient-background()` instead.
+  If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
+}
+
 // Font-sizing and vertical rhythm mixin
 // ===========================================
 
-// Please see tools/typography for `text()` replacement.
+// Please see tools/typography for `@include font()` replacement.
 @mixin font-size($args...) {
   @include font($args...);
   @warn "Deprecation [mixin]: `@include font-size()`
   Support for `@include font-size()` will be removed in Toolkit@2.0.0. Use `@include font()` instead.
+  If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
+}
+
+// Background gradient page mixin
+// ===========================================
+
+// Please see tools/page for `@include page-background()` replacement.
+@mixin background-page($args...) {
+  @include page-background($args...);
+  @warn "Deprecation [mixin]: `@include background-page()`
+  Support for `@include background-page()` will be removed in Toolkit@2.0.0. Use `@include page-background()` instead.
   If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
 }
 

--- a/tools/_page.scss
+++ b/tools/_page.scss
@@ -9,10 +9,10 @@
 // Example usage:
 //
 //   html {
-//     @include background-page();
+//     @include page-background();
 //   }
 
-@mixin background-page() {
+@mixin page-background() {
   @include background-gradient("small", horizontal);
 
   @include mq($from: medium) {

--- a/tools/_page.scss
+++ b/tools/_page.scss
@@ -13,7 +13,7 @@
 //   }
 
 @mixin page-background() {
-  @include background-gradient("small", horizontal);
+  @include gradient-background("small", horizontal);
 
   @include mq($from: medium) {
     background-color: color(grey-10);

--- a/utilities/_defence.scss
+++ b/utilities/_defence.scss
@@ -4,7 +4,7 @@
 
 /* stylelint-disable string-no-newline */
 @warn "Deprecation [utility]: Defence
-Support for `_defence.scss` will be removed in Toolkit@2.0.0 due to deprecation of the existing Masthead.
+Support for `_defence.scss` will be removed in Toolkit@3.0.0 due to deprecation of the existing Masthead.
 If you experience any issues with this required change, please visit https://git.io/v9b7v for next steps.";
 /* stylelint-enable */
 


### PR DESCRIPTION
## Description
- Rename our mixins to prepare for 2.0 deprecation
- Change warning for defence to 3.0

## Related Issue
https://github.com/sky-uk/toolkit/issues/223

## Motivation and Context
Further 2.0 development

## How Has This Been Tested?
All tests pass

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
