### PR TITLE
Prevent Horizontal Scrolling by Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ### Features
 
-* [colors] `grey-40` modified to meet AA accessibility.
-* [typography] Updated sizing to the typographic scale.
+* [Colors] `grey-40` modified to meet AA accessibility.
+* [Typography] Updated sizing to the typographic scale.
 * [z-index] `z-index()` function for easier access and management of `z-index` values across the project.
 
 ### Dependencies
@@ -19,16 +19,17 @@
 
 ### Deprecations
 
-* [typography] Removal of `text-lead-small` and `text-body-small` from `$text`.
+* [Typography] Removal of `text-lead-small` and `text-body-small` from `$text`.
     * Please use `text-body` instead.
 
 ### Fixes
 
+* [Generic] Horizontal scrolling bugs caused by full-width (`100vw`) UI elements.
 * [Sass-MQ] Tell Sass MQ to use our actual base font size and not its
   pre-defined setting.
 
 ### Upgrade notes
-* [spacing] Default spacing unit value changed from 30px to 20px.
+* [Spacing] Default spacing unit value changed from 30px to 20px.
     * **Variables** - if used in your project, you may want to consider changing the following:
         * `$global-spacing-unit-small` to `$global-spacing-unit`
         * `$global-spacing-unit-tiny` to `$global-spacing-unit-small`
@@ -43,7 +44,7 @@
         * `.u-margin-right-tiny` to `.u-margin-right-small`
         * `.u-margin-bottom-tiny` to `.u-margin-bottom-small`
         * `.u-margin-left-tiny` to `.u-margin-left-small`
-
+* [Horizontal Scrolling] If your app uses horizontal scrolling, you may need to apply `.u-overflow-x-scroll` to your `<html>` and `<body>` elements.
 
 ## 1.15.0
 

--- a/_all.scss
+++ b/_all.scss
@@ -31,9 +31,10 @@
  * Normalize.css........Normalise differences across different browsers.
  * Reset................Simple reset to complement Normalize.css: set everything
  *                      to zero.
+ * Overflow.............Prevent horizontal scrolling by default.
  * Vertical Rhythm......Define common vertical spacing across all block-level
  *                      elements in one go.
- * Generic..............Our @keyframe definitions for animations.
+ * Keyframes............Our @keyframe definitions for animations.
  *
  * ELEMENTS
  * Page.................Set up our HTML and/or BODY elements.
@@ -78,6 +79,7 @@
  * Debug................Enabling debugging mode will point out various errors
  *                      and mistakes in our HTML.
  * Fill.................Utility classes to position an element within its parent.
+ * Overflow.............Utility classes to control element overflow.
  */
 
 // Settings
@@ -91,6 +93,7 @@
 @import "generic/box-sizing";
 @import "normalize.css/normalize";
 @import "generic/reset";
+@import "generic/overflow";
 @import "generic/vertical-rhythm";
 @import "generic/keyframes";
 
@@ -121,6 +124,7 @@
 @import "utilities/ie9";
 @import "utilities/debug";
 @import "utilities/fill";
+@import "utilities/overflow";
 
 // Assertions
 @import "test/assertions/all";

--- a/generic/_overflow.scss
+++ b/generic/_overflow.scss
@@ -6,7 +6,7 @@
  * As browsers interpret `vw` differently, some of our full-width (`100vw`) UI
  * components cause unwanted horizontal scrolling.
  *
- * This can be overriden using the classes in utilities/overflow
+ * Note: this can be overriden using the classes in utilities/overflow.
  */
 html,
 body {

--- a/generic/_overflow.scss
+++ b/generic/_overflow.scss
@@ -1,0 +1,14 @@
+/* ==========================================================================
+   GENERIC / #OVERFLOW
+   ========================================================================== */
+
+/**
+ * As browsers interpret `vw` differently, some of our full-width (`100vw`) UI
+ * components cause unwanted horizontal scrolling.
+ *
+ * This can be overriden using the classes in utilities/overflow
+ */
+html,
+body {
+  overflow-x: hidden;
+}

--- a/tools/_page.scss
+++ b/tools/_page.scss
@@ -16,7 +16,7 @@
   @include background-gradient("small", horizontal);
 
   @include mq($from: medium) {
-    background-color: color(grey-10);
+    background-color: color(white);
     background-image: -webkit-linear-gradient(left, #c9c7d1 0%, #e5e5ea 6%, #fefefe 20%, #fefefe 80%, #e5e5ea 94%, #c9c7d1 100%);
     background-image: -moz-linear-gradient(left, #c9c7d1 0%, #e5e5ea 6%, #fefefe 20%, #fefefe 80%, #e5e5ea 94%, #c9c7d1 100%);
     background-image: -o-linear-gradient(left, #c9c7d1 0%, #e5e5ea 6%, #fefefe 20%, #fefefe 80%, #e5e5ea 94%, #c9c7d1 100%);

--- a/utilities/_overflow.scss
+++ b/utilities/_overflow.scss
@@ -1,0 +1,14 @@
+/* ==========================================================================
+   UTILITIES / #OVERFLOW
+   ========================================================================== */
+
+/**
+ * Enable Horizontal Scrolling
+ *
+ * Recommended for overriding the hidden horizontal scrolling set by
+ * generic/overflow.
+ */
+.u-overflow-x-scroll {
+  /*! autoprefixer: off */
+  overflow-x: scroll !important;
+}

--- a/utilities/_overflow.scss
+++ b/utilities/_overflow.scss
@@ -9,6 +9,5 @@
  * generic/overflow.
  */
 .u-overflow-x-scroll {
-  /*! autoprefixer: off */
   overflow-x: scroll !important;
 }


### PR DESCRIPTION
## Description
Prevent horizontal scrolling by default, providing utility for overriding where necessary.

Solution proposed by @JamieMason 

## Related Issue
https://github.com/sky-uk/toolkit/issues/231

## Motivation and Context
Further 2.0 development

## How Has This Been Tested?
All tests pass

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [ ] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [x] CHANGELOG.md updated.
