### PR TITLE
Fixed weird breakpoint issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@
 ### Fixes
 
 * [Generic] Horizontal scrolling bugs caused by full-width (`100vw`) UI elements.
-* [Sass-MQ] Tell Sass MQ to use our actual base font size and not its
-  pre-defined setting.
 
 ### Upgrade notes
 * [Spacing] Default spacing unit value changed from 30px to 20px.

--- a/settings/_breakpoints.scss
+++ b/settings/_breakpoints.scss
@@ -10,6 +10,10 @@
 // which that breakpoint kicks in. These pixel values will be conveted into ems
 // by Sass MQ.
 //
+// Note: Sass MQ's `em` values are calculated via the browser-default HTML 
+//       font-size of `16px`, *not* Toolkit's $global-font-size.
+//       Further reading: https://stackoverflow.com/a/39935188
+//
 // Make use of these breakpoints like so:
 //
 //   .foo {

--- a/settings/_breakpoints.scss
+++ b/settings/_breakpoints.scss
@@ -40,16 +40,6 @@ $mq-breakpoints: (
   x-large: 1300px
 ) !default;
 
-// Sass MQ Configuration
-// ==============================================
-
-// Sass MQ needs telling about our base font size so that it can generate the
-// appropriate em-based media queries. Luckily our base font size is already
-// contained in a variable, so we can just map Sass MQ onto that. Further, any
-// time we make a change to our project’s font size, Sass MQ will always pick it
-// up automatically.
-$mq-base-font-size: $global-font-size;
-
 // Supercell Configuration
 // ==============================================
 


### PR DESCRIPTION
## Description
This removes the config line for Sass-Mq so we don't have bizarre breakpoint behaviour

Here is some reading on the issue https://stackoverflow.com/questions/39934812/is-is-possible-to-overwrite-the-browsers-default-font-size-in-media-queries-usi

This explains the root issue. (no pun intended)

To summarise setting the font-size on HTML cascades down our style sheets as you would expect. This however doesn't have any impact on the browser base font size which is used to calculate media queries.

The only way in which you could have media queries relating to the font-size set is via element queries which are not currently supported.

## Related Issue
https://github.com/sky-uk/toolkit/issues/203

## Motivation and Context
Why is this change required?

Breakpoints are broken

What problem does it solve?

Breakpoints now work

What program is it supporting? e.g. Toolkit evolution / Sky Mobile

Illuminate

## How Has This Been Tested?
Tested on the Sky Mobile sales site locally.

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [ ] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [ ] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [ ] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.

